### PR TITLE
Avoid intermediate QUBO files for MQLib runs

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -1,6 +1,6 @@
 name = "MQLib"
 uuid = "16f11440-1623-44c9-850c-358a6c72f3c9"
-authors = ["pedromxavier <mail@pedro.ϵλ>", "pedroripper <pedroripper@psr-inc.com>"]
+authors = ["pedromxavier <mail@pedro.ϵλ>", "pedroripper <pedroripper@psr-inc.com>", "David E. Bernal Neira <dbernaln@purdue.edu>"]
 version = "0.4.1"
 
 [deps]

--- a/README.md
+++ b/README.md
@@ -49,3 +49,9 @@ To list available heuristics and their descriptions, run:
 ```julia
 MQLib.show_heuristics()
 ```
+
+## Authors
+
+- pedromxavier <mail@pedro.ϵλ>
+- pedroripper <pedroripper@psr-inc.com>
+- David E. Bernal Neira <dbernaln@purdue.edu>

--- a/src/MQLib.jl
+++ b/src/MQLib.jl
@@ -9,6 +9,18 @@ import MathOptInterface as MOI
 
 const __VERSION__ = v"0.1.0"
 const _HEURISTICS = Dict{String,String}()
+const _MQLIB_STDIN = "/dev/stdin"
+
+abstract type _MQLibInput end
+
+struct _MQLibFileInput <: _MQLibInput
+    file_path::String
+end
+
+struct _MQLibStdinInput <: _MQLibInput
+    data::Vector{UInt8}
+    file_path::String
+end
 
 function __init__()
     let exe = MQLib_jll.MQLib()
@@ -80,16 +92,14 @@ function QUBODrivers.sample(sampler::Optimizer{T}) where {T}
     )
 
     mktempdir() do temp_path
-        file_path = joinpath(temp_path, "model.qubo")
+        input = _mqlib_input(model, joinpath(temp_path, "model.qubo"))
 
         args = _mqlib_args(;
-            file_path,
+            file_path = _mqlib_file_path(input),
             heuristic,
             random_seed,
             run_time_limit,
         )
-
-        QUBOTools.write_model(file_path, model, QUBOTools.Format{:qubo}(; style = :mqlib))
 
         let exe = MQLib_jll.MQLib()
             cmd = `$exe $args`
@@ -99,7 +109,7 @@ function QUBODrivers.sample(sampler::Optimizer{T}) where {T}
             t = 0.0
             
             for i = 1:num_reads
-                lines = readlines(cmd)
+                lines = _mqlib_readlines(cmd, input)
                 info  = split(lines[begin], ',')
 
                 λ = parse(T, info[4])
@@ -123,6 +133,30 @@ function QUBODrivers.sample(sampler::Optimizer{T}) where {T}
     end
 
     return QUBOTools.SampleSet{T}(samples, metadata; sense = :max, domain = :bool)
+end
+
+function _mqlib_input(model::QUBOTools.AbstractModel, file_path::String)
+    if _supports_mqlib_stdin()
+        io = IOBuffer()
+
+        QUBOTools.write_model(io, model, QUBOTools.Format{:qubo}(; style = :mqlib))
+
+        return _MQLibStdinInput(take!(io), _MQLIB_STDIN)
+    else
+        QUBOTools.write_model(file_path, model, QUBOTools.Format{:qubo}(; style = :mqlib))
+
+        return _MQLibFileInput(file_path)
+    end
+end
+
+_mqlib_file_path(input::_MQLibInput) = input.file_path
+
+_supports_mqlib_stdin() = Sys.isunix() && ispath(_MQLIB_STDIN)
+
+_mqlib_readlines(cmd::Cmd, input::_MQLibFileInput) = readlines(cmd)
+
+function _mqlib_readlines(cmd::Cmd, input::_MQLibStdinInput)
+    return readlines(pipeline(cmd; stdin = IOBuffer(input.data)))
 end
 
 function _print_header(silent::Bool, heuristic::Union{String,Nothing})

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -1,5 +1,45 @@
 import MQLib
 import MQLib: MOI, QUBODrivers
+import Test
+
+const QUBOTools = MQLib.QUBOTools
+
+function test_model()
+    return QUBOTools.Model{Int,Float64,Int}(
+        Set(1:2),
+        Dict(1 => 1.0, 2 => -1.0),
+        Dict((1, 2) => 2.0);
+        scale = 1.0,
+        offset = 0.0,
+        sense = :max,
+        domain = :bool,
+    )
+end
+
+Test.@testset "MQLib input" begin
+    model = test_model()
+    io = IOBuffer()
+
+    QUBOTools.write_model(io, model, QUBOTools.Format{:qubo}(; style = :mqlib))
+
+    expected = String(take!(io))
+
+    mktempdir() do dir
+        file_path = joinpath(dir, "model.qubo")
+        input = MQLib._mqlib_input(model, file_path)
+
+        if MQLib._supports_mqlib_stdin()
+            Test.@test input isa MQLib._MQLibStdinInput
+            Test.@test MQLib._mqlib_file_path(input) == MQLib._MQLIB_STDIN
+            Test.@test String(copy(input.data)) == expected
+            Test.@test !isfile(file_path)
+        else
+            Test.@test input isa MQLib._MQLibFileInput
+            Test.@test MQLib._mqlib_file_path(input) == file_path
+            Test.@test read(file_path, String) == expected
+        end
+    end
+end
 
 QUBODrivers.test(MQLib.Optimizer) do model
     MOI.set(model, MOI.Silent(), true)


### PR DESCRIPTION
## Summary

- Stream the generated QUBO model to MQLib through `/dev/stdin` on Unix platforms, avoiding an intermediate `.qubo` file on disk.
- Keep the existing tempfile-backed path as a fallback for platforms without `/dev/stdin`, including Windows.
- Add focused tests for MQLib input selection and model serialization.
- Add David E. Bernal Neira to the package authors and README authors.

Note: the current `MQLib_jll` build recipe only installs `ExecutableProduct("MQLib")`; it does not provide a shared-library product or C ABI. This PR isolates the executable input boundary and removes the file write where the current artifact supports doing so, but it does not yet implement direct shared-library access.

## Follow-up work for direct shared-library access

- #9: Add a stable C ABI for solving QUBOs with MQLib.
- #7: Build `MQLib_jll` with a shared library product.
- #8: Use the MQLib shared library from MQLib.jl.

## Tests run

- `julia +1.12 --project=. test/runtests.jl` - passed (`MQLib input`: 4 passed; QUBODrivers suite: 124 passed).
- `julia +1.12 --project=. -e 'using Pkg; Pkg.test()'` from `/tmp/mqlib-ci-test.RMVVVu`, a CI-like copy without the repo's ignored local `Manifest.toml` - passed.
- `git -c core.whitespace=cr-at-eol diff --check` - passed.

## Notes about tests not run

- `julia +1.12 --project=. -e 'using Pkg; Pkg.test()'` directly in this checkout was not usable because the ignored local `Manifest.toml` pins path dependencies from this machine and conflicts with the current QUBOTools checkout version. The CI-like temporary-copy run above excludes that ignored manifest.
- Windows CI was not run locally.

Refs #3
