### PR TITLE
Add stable QUBO C ABI wrapper

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -28,6 +28,8 @@ jobs:
       - uses: julia-actions/julia-buildpkg@v1
       - name: Native C ABI smoke test
         if: runner.os == 'Linux'
+        env:
+          MQLIB_UPSTREAM_REF: 585496274af5abb0849d0d47e135496b4688680b
         run: bash test/native_c_api_smoke.sh
       - uses: julia-actions/julia-runtest@v1
       # - uses: julia-actions/julia-processcoverage@v1

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -26,6 +26,9 @@ jobs:
           version: ${{ matrix.version }}
           arch: ${{ matrix.arch }}
       - uses: julia-actions/julia-buildpkg@v1
+      - name: Native C ABI smoke test
+        if: runner.os == 'Linux'
+        run: bash test/native_c_api_smoke.sh
       - uses: julia-actions/julia-runtest@v1
       # - uses: julia-actions/julia-processcoverage@v1
       # - uses: codecov/codecov-action@v2

--- a/c_api/README.md
+++ b/c_api/README.md
@@ -1,0 +1,57 @@
+# MQLib C ABI
+
+This directory defines the native C ABI for solving QUBO instances through
+MQLib without invoking the command-line executable.
+
+The files here are intended to be compiled with the upstream MQLib C++ sources
+and packaged as a shared library by `MQLib_jll`. The Julia wrapper does not call
+this ABI yet; that integration belongs to the follow-up shared-library issue.
+
+## API
+
+Include `c_api/include/mqlib_c_api.h` from C, C++, or Julia `ccall` bindings.
+The public ABI exposes only C scalars, pointers, and structs:
+
+- `MQLibCQUBOInput` passes the problem dimension, linear coefficients, sparse
+  off-diagonal quadratic coordinate arrays, heuristic selection, runtime limit,
+  and random seed.
+- `MQLibCQUBOResult` passes caller-owned buffers for the objective value,
+  binary solution vector, runtime, selected heuristic, and optional incumbent
+  history.
+- `mqlib_solve_qubo` returns a stable `MQLibCStatus` code. It does not transfer
+  ownership of any caller buffer.
+
+The wrapper validates ABI inputs before constructing MQLib C++ objects and
+reports those failures through status codes. Unrecoverable exits inside
+upstream heuristic internals are still upstream behavior until those internals
+are made status-code aware.
+
+Quadratic coordinates may be zero-based or one-based, selected by
+`index_base`. Diagonal terms belong in `linear`; quadratic arrays must contain
+only off-diagonal entries. MQLib interprets off-diagonal entries as the upper
+triangle of the symmetric QUBO matrix, matching the existing MQLib `.qubo` file
+format.
+
+Set `heuristic` to a QUBO heuristic code such as `ALKHAMIS1998` to run that
+heuristic. Set it to `NULL` or an empty string to run the hyperheuristic path.
+
+## Build Sketch
+
+The exact build recipe belongs in `MQLib_jll`, but a local syntax check against
+an upstream MQLib checkout looks like:
+
+```sh
+c++ -std=c++11 \
+  -Ic_api/include \
+  -I/path/to/MQLib/include \
+  -fsyntax-only \
+  c_api/src/mqlib_c_api.cpp
+```
+
+When building the shared library, compile `c_api/src/mqlib_c_api.cpp` together
+with the upstream MQLib implementation sources needed by the heuristics. The
+upstream executable entry point (`src/main.cpp`) should not be part of the
+shared-library target.
+
+The small native example in `c_api/examples/solve_qubo.c` demonstrates both an
+explicit QUBO heuristic and the hyperheuristic call shape.

--- a/c_api/README.md
+++ b/c_api/README.md
@@ -34,6 +34,10 @@ format.
 
 Set `heuristic` to a QUBO heuristic code such as `ALKHAMIS1998` to run that
 heuristic. Set it to `NULL` or an empty string to run the hyperheuristic path.
+For hyperheuristic runs, set `hyperheuristic_data_dir` to the directory
+containing MQLib's random-forest model files, usually the upstream `hhdata`
+directory. If no model files are found, `mqlib_solve_qubo` returns
+`MQLIB_STATUS_HYPERHEURISTIC_DATA_NOT_FOUND`.
 
 ## Build Sketch
 
@@ -54,4 +58,8 @@ upstream executable entry point (`src/main.cpp`) should not be part of the
 shared-library target.
 
 The small native example in `c_api/examples/solve_qubo.c` demonstrates both an
-explicit QUBO heuristic and the hyperheuristic call shape.
+explicit QUBO heuristic and the hyperheuristic call shape:
+
+```sh
+./solve_qubo /path/to/MQLib/hhdata
+```

--- a/c_api/examples/solve_qubo.c
+++ b/c_api/examples/solve_qubo.c
@@ -2,7 +2,7 @@
 
 #include "mqlib_c_api.h"
 
-static int solve_with_heuristic(const char *heuristic) {
+static int solve_with_heuristic(const char *heuristic, const char *hhdata_dir) {
     const double linear[3] = {5.0, 3.0, 1.0};
     const int32_t quadratic_i[2] = {0, 1};
     const int32_t quadratic_j[2] = {1, 2};
@@ -24,7 +24,8 @@ static int solve_with_heuristic(const char *heuristic) {
         MQLIB_C_INDEX_BASE_ZERO,
         heuristic,
         0.01,
-        1234
+        1234,
+        hhdata_dir
     };
 
     MQLibCQUBOResult result = {
@@ -59,11 +60,16 @@ static int solve_with_heuristic(const char *heuristic) {
     return MQLIB_STATUS_OK;
 }
 
-int main(void) {
-    int status = solve_with_heuristic("ALKHAMIS1998");
+int main(int argc, char **argv) {
+    int status = solve_with_heuristic("ALKHAMIS1998", NULL);
     if (status != MQLIB_STATUS_OK) {
         return status;
     }
 
-    return solve_with_heuristic(NULL);
+    if (argc < 2) {
+        fprintf(stderr, "Pass the path to MQLib's hhdata directory to run the hyperheuristic example.\n");
+        return 2;
+    }
+
+    return solve_with_heuristic(NULL, argv[1]);
 }

--- a/c_api/examples/solve_qubo.c
+++ b/c_api/examples/solve_qubo.c
@@ -1,0 +1,69 @@
+#include <stdio.h>
+
+#include "mqlib_c_api.h"
+
+static int solve_with_heuristic(const char *heuristic) {
+    const double linear[3] = {5.0, 3.0, 1.0};
+    const int32_t quadratic_i[2] = {0, 1};
+    const int32_t quadratic_j[2] = {1, 2};
+    const double quadratic_value[2] = {-6.0, -1.0};
+
+    int32_t solution[3] = {0, 0, 0};
+    char selected_heuristic[64];
+    double history_values[32];
+    double history_times[32];
+
+    MQLibCQUBOInput input = {
+        MQLIB_C_ABI_VERSION,
+        3,
+        linear,
+        2,
+        quadratic_i,
+        quadratic_j,
+        quadratic_value,
+        MQLIB_C_INDEX_BASE_ZERO,
+        heuristic,
+        0.01,
+        1234
+    };
+
+    MQLibCQUBOResult result = {
+        MQLIB_C_ABI_VERSION,
+        0.0,
+        0.0,
+        solution,
+        3,
+        selected_heuristic,
+        (int32_t)sizeof(selected_heuristic),
+        history_values,
+        history_times,
+        32,
+        0
+    };
+
+    const int status = mqlib_solve_qubo(&input, &result);
+    if (status != MQLIB_STATUS_OK) {
+        fprintf(stderr, "MQLib failed: %s\n", mqlib_c_status_message(status));
+        return status;
+    }
+
+    printf(
+        "%s objective %.15g solution %d %d %d runtime %.6f seconds\n",
+        result.selected_heuristic,
+        result.objective_value,
+        result.solution[0],
+        result.solution[1],
+        result.solution[2],
+        result.runtime_seconds
+    );
+    return MQLIB_STATUS_OK;
+}
+
+int main(void) {
+    int status = solve_with_heuristic("ALKHAMIS1998");
+    if (status != MQLIB_STATUS_OK) {
+        return status;
+    }
+
+    return solve_with_heuristic(NULL);
+}

--- a/c_api/examples/solve_qubo.c
+++ b/c_api/examples/solve_qubo.c
@@ -2,7 +2,11 @@
 
 #include "mqlib_c_api.h"
 
-static int solve_with_heuristic(const char *heuristic, const char *hhdata_dir) {
+static int solve_with_heuristic(
+    const char *heuristic,
+    const char *hhdata_dir,
+    double runtime_limit_seconds
+) {
     const double linear[3] = {5.0, 3.0, 1.0};
     const int32_t quadratic_i[2] = {0, 1};
     const int32_t quadratic_j[2] = {1, 2};
@@ -23,7 +27,7 @@ static int solve_with_heuristic(const char *heuristic, const char *hhdata_dir) {
         quadratic_value,
         MQLIB_C_INDEX_BASE_ZERO,
         heuristic,
-        0.01,
+        runtime_limit_seconds,
         1234,
         hhdata_dir
     };
@@ -61,7 +65,7 @@ static int solve_with_heuristic(const char *heuristic, const char *hhdata_dir) {
 }
 
 int main(int argc, char **argv) {
-    int status = solve_with_heuristic("ALKHAMIS1998", NULL);
+    int status = solve_with_heuristic("ALKHAMIS1998", NULL, 0.01);
     if (status != MQLIB_STATUS_OK) {
         return status;
     }
@@ -71,5 +75,5 @@ int main(int argc, char **argv) {
         return 2;
     }
 
-    return solve_with_heuristic(NULL, argv[1]);
+    return solve_with_heuristic(NULL, argv[1], 0.75);
 }

--- a/c_api/examples/solve_qubo.c
+++ b/c_api/examples/solve_qubo.c
@@ -75,5 +75,5 @@ int main(int argc, char **argv) {
         return 2;
     }
 
-    return solve_with_heuristic(NULL, argv[1], 0.75);
+    return solve_with_heuristic(NULL, argv[1], 1.50);
 }

--- a/c_api/include/mqlib_c_api.h
+++ b/c_api/include/mqlib_c_api.h
@@ -1,0 +1,98 @@
+#ifndef MQLIB_C_API_H
+#define MQLIB_C_API_H
+
+#include <stdint.h>
+
+#define MQLIB_C_ABI_VERSION 1u
+
+#define MQLIB_C_INDEX_BASE_ZERO 0
+#define MQLIB_C_INDEX_BASE_ONE 1
+
+#if defined(_WIN32) && defined(MQLIB_C_BUILD_SHARED)
+#define MQLIB_C_API __declspec(dllexport)
+#elif defined(_WIN32) && defined(MQLIB_C_USE_SHARED)
+#define MQLIB_C_API __declspec(dllimport)
+#else
+#define MQLIB_C_API
+#endif
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+typedef enum MQLibCStatus {
+    MQLIB_STATUS_OK = 0,
+    MQLIB_STATUS_ABI_VERSION_MISMATCH = 1,
+    MQLIB_STATUS_INVALID_ARGUMENT = 2,
+    MQLIB_STATUS_INVALID_HEURISTIC = 3,
+    MQLIB_STATUS_BUFFER_TOO_SMALL = 4,
+    MQLIB_STATUS_ALLOCATION_FAILED = 5,
+    MQLIB_STATUS_INTERNAL_ERROR = 6
+} MQLibCStatus;
+
+typedef struct MQLibCQUBOInput {
+    uint32_t abi_version;
+
+    int32_t dimension;
+    const double *linear;
+
+    int64_t quadratic_count;
+    const int32_t *quadratic_i;
+    const int32_t *quadratic_j;
+    const double *quadratic_value;
+    int32_t index_base;
+
+    /*
+     * NULL or an empty string runs the MQLib hyperheuristic. Otherwise this
+     * must be a valid MQLib QUBO or Max-Cut heuristic code.
+     */
+    const char *heuristic;
+
+    double runtime_limit_seconds;
+    int32_t random_seed;
+} MQLibCQUBOInput;
+
+typedef struct MQLibCQUBOResult {
+    uint32_t abi_version;
+
+    double objective_value;
+    double runtime_seconds;
+
+    /*
+     * Caller-owned buffer with capacity in solution_length on input. The
+     * required length is written back on output.
+     */
+    int32_t *solution;
+    int32_t solution_length;
+
+    /*
+     * Optional caller-owned buffer. selected_heuristic_length is the byte
+     * capacity on input and the required byte count, including NUL, on output.
+     */
+    char *selected_heuristic;
+    int32_t selected_heuristic_length;
+
+    /*
+     * Optional caller-owned buffers for objective history. history_capacity is
+     * the input capacity of both arrays. history_length is the required entry
+     * count on output. If the capacity is too small, the prefix that fits is
+     * copied and MQLIB_STATUS_BUFFER_TOO_SMALL is returned.
+     */
+    double *history_objective_values;
+    double *history_times_seconds;
+    int32_t history_capacity;
+    int32_t history_length;
+} MQLibCQUBOResult;
+
+MQLIB_C_API int mqlib_c_abi_version(void);
+MQLIB_C_API const char *mqlib_c_status_message(int status);
+MQLIB_C_API int mqlib_solve_qubo(
+    const MQLibCQUBOInput *input,
+    MQLibCQUBOResult *result
+);
+
+#ifdef __cplusplus
+}
+#endif
+
+#endif

--- a/c_api/include/mqlib_c_api.h
+++ b/c_api/include/mqlib_c_api.h
@@ -27,7 +27,8 @@ typedef enum MQLibCStatus {
     MQLIB_STATUS_INVALID_HEURISTIC = 3,
     MQLIB_STATUS_BUFFER_TOO_SMALL = 4,
     MQLIB_STATUS_ALLOCATION_FAILED = 5,
-    MQLIB_STATUS_INTERNAL_ERROR = 6
+    MQLIB_STATUS_INTERNAL_ERROR = 6,
+    MQLIB_STATUS_HYPERHEURISTIC_DATA_NOT_FOUND = 7
 } MQLibCStatus;
 
 typedef struct MQLibCQUBOInput {
@@ -50,6 +51,14 @@ typedef struct MQLibCQUBOInput {
 
     double runtime_limit_seconds;
     int32_t random_seed;
+
+    /*
+     * Optional path to the directory containing the hyperheuristic .rf model
+     * files. Used only when heuristic is NULL or empty. If this is NULL or
+     * empty, mqlib_solve_qubo looks for ./hhdata relative to the caller's
+     * current working directory.
+     */
+    const char *hyperheuristic_data_dir;
 } MQLibCQUBOInput;
 
 typedef struct MQLibCQUBOResult {

--- a/c_api/src/mqlib_c_api.cpp
+++ b/c_api/src/mqlib_c_api.cpp
@@ -5,6 +5,7 @@
 #include <cstdlib>
 #include <cstring>
 #include <exception>
+#include <fstream>
 #include <limits>
 #include <memory>
 #include <sstream>
@@ -13,16 +14,35 @@
 #include <vector>
 
 #include "heuristics/heuristic_factory.h"
-#include "heuristics/maxcut/hyperheuristic.h"
+#include "heuristics/maxcut/max_cut_simple_solution.h"
 #include "heuristics/qubo/qubo_simple_solution.h"
+#include "metrics/max_cut_metrics.h"
 #include "problem/max_cut_instance.h"
 #include "problem/qubo_instance.h"
+#include "util/random.h"
+#include "util/randomForest.h"
 
 namespace {
 
 bool has_text(const char *value) {
     return value != NULL && value[0] != '\0';
 }
+
+enum HyperheuristicProblem {
+    HYPERHEURISTIC_MAXCUT,
+    HYPERHEURISTIC_QUBO
+};
+
+struct HyperheuristicChoice {
+    bool found;
+    HyperheuristicProblem problem;
+    std::string code;
+
+    HyperheuristicChoice() :
+        found(false),
+        problem(HYPERHEURISTIC_MAXCUT),
+        code() {}
+};
 
 bool parse_double_token(const std::string &text, double *value) {
     char *end = NULL;
@@ -68,6 +88,101 @@ bool parse_history(
     }
 
     return true;
+}
+
+std::string model_path(const std::string &data_dir, const std::string &code) {
+    const std::string root = data_dir.empty() ? std::string("hhdata") : data_dir;
+    return root + "/" + code + ".rf";
+}
+
+bool file_exists(const std::string &path) {
+    std::ifstream file(path.c_str());
+    return file.good();
+}
+
+void update_hyperheuristic_choice(
+    const std::string &code,
+    HyperheuristicProblem problem,
+    const std::vector<double> &metrics,
+    const std::string &data_dir,
+    double *best_probability,
+    int *num_best,
+    HyperheuristicChoice *choice
+) {
+    const std::string path = model_path(data_dir, code);
+    if (!file_exists(path)) {
+        return;
+    }
+
+    RandomForest random_forest(path);
+    const double probability = random_forest.Predict(metrics);
+    if (probability > *best_probability) {
+        *best_probability = probability;
+        *num_best = 1;
+        choice->found = true;
+        choice->problem = problem;
+        choice->code = code;
+    } else if (probability == *best_probability &&
+               Random::RandInt(0, *num_best) == *num_best) {
+        ++(*num_best);
+        choice->found = true;
+        choice->problem = problem;
+        choice->code = code;
+    }
+}
+
+int select_hyperheuristic(
+    HeuristicFactory *factory,
+    const MaxCutInstance &mi,
+    const char *hyperheuristic_data_dir,
+    HyperheuristicChoice *choice
+) {
+    GraphMetrics graph_metrics(mi);
+    std::vector<double> metrics;
+    graph_metrics.AllMetrics(&metrics, NULL);
+
+    const std::string data_dir = has_text(hyperheuristic_data_dir) ?
+        std::string(hyperheuristic_data_dir) :
+        std::string();
+    double best_probability = -1.0;
+    int num_best = 1;
+
+    std::vector<std::string> codes;
+    factory->MaxCutHeuristicCodes(&codes);
+    for (std::vector<std::string>::const_iterator code = codes.begin();
+         code != codes.end();
+         ++code) {
+        update_hyperheuristic_choice(
+            *code,
+            HYPERHEURISTIC_MAXCUT,
+            metrics,
+            data_dir,
+            &best_probability,
+            &num_best,
+            choice
+        );
+    }
+
+    factory->QUBOHeuristicCodes(&codes);
+    for (std::vector<std::string>::const_iterator code = codes.begin();
+         code != codes.end();
+         ++code) {
+        update_hyperheuristic_choice(
+            *code,
+            HYPERHEURISTIC_QUBO,
+            metrics,
+            data_dir,
+            &best_probability,
+            &num_best,
+            choice
+        );
+    }
+
+    if (!choice->found) {
+        return MQLIB_STATUS_HYPERHEURISTIC_DATA_NOT_FOUND;
+    }
+
+    return MQLIB_STATUS_OK;
 }
 
 int validate_buffers(
@@ -237,11 +352,13 @@ int solve_qubo_impl(
     QUBOInstance qi(quadratic, linear, static_cast<int>(input->dimension));
     HeuristicFactory factory;
     std::unique_ptr<MaxCutInstance> mi;
+    std::unique_ptr<QUBOInstance> hyperheuristic_qi;
     std::unique_ptr<MaxCutHeuristic> maxcut_heuristic;
     std::unique_ptr<QUBOHeuristic> qubo_heuristic;
     Heuristic *heuristic = NULL;
     std::string selected;
     const bool validation = false;
+    bool qubo_solution_uses_original_instance = true;
 
     if (has_text(input->heuristic)) {
         const std::string requested(input->heuristic);
@@ -271,17 +388,40 @@ int solve_qubo_impl(
         }
     } else {
         mi.reset(new MaxCutInstance(qi));
-        std::string hyperheuristic_choice;
-        maxcut_heuristic.reset(new MaxCutHyperheuristic(
+        HyperheuristicChoice choice;
+        status = select_hyperheuristic(
+            &factory,
             *mi,
-            input->runtime_limit_seconds,
-            validation,
-            NULL,
-            static_cast<int>(input->random_seed),
-            &hyperheuristic_choice
-        ));
-        heuristic = maxcut_heuristic.get();
-        selected = "HH_" + hyperheuristic_choice;
+            input->hyperheuristic_data_dir,
+            &choice
+        );
+        if (status != MQLIB_STATUS_OK) {
+            return status;
+        }
+
+        std::srand(static_cast<unsigned int>(input->random_seed));
+        if (choice.problem == HYPERHEURISTIC_MAXCUT) {
+            maxcut_heuristic.reset(factory.RunMaxCutHeuristic(
+                choice.code,
+                *mi,
+                input->runtime_limit_seconds,
+                validation,
+                NULL
+            ));
+            heuristic = maxcut_heuristic.get();
+        } else {
+            hyperheuristic_qi.reset(new QUBOInstance(*mi));
+            qubo_heuristic.reset(factory.RunQUBOHeuristic(
+                choice.code,
+                *hyperheuristic_qi,
+                input->runtime_limit_seconds,
+                validation,
+                NULL
+            ));
+            heuristic = qubo_heuristic.get();
+            qubo_solution_uses_original_instance = false;
+        }
+        selected = "HH_" + choice.code;
     }
 
     if (heuristic == NULL) {
@@ -293,8 +433,15 @@ int solve_qubo_impl(
     std::vector<int> assignments;
     if (qubo_heuristic.get() != NULL) {
         const QUBOSimpleSolution &solution = qubo_heuristic->get_best_solution();
-        assignments = solution.get_assignments();
-        result->objective_value = solution.get_weight();
+        if (qubo_solution_uses_original_instance) {
+            assignments = solution.get_assignments();
+            result->objective_value = solution.get_weight();
+        } else {
+            MaxCutSimpleSolution maxcut_solution(solution, *mi, NULL);
+            QUBOSimpleSolution qubo_solution(maxcut_solution, qi, NULL);
+            assignments = qubo_solution.get_assignments();
+            result->objective_value = qubo_solution.get_weight();
+        }
     } else {
         QUBOSimpleSolution solution(
             maxcut_heuristic->get_best_solution(),
@@ -352,6 +499,8 @@ extern "C" MQLIB_C_API const char *mqlib_c_status_message(int status) {
         return "allocation failed";
     case MQLIB_STATUS_INTERNAL_ERROR:
         return "internal error";
+    case MQLIB_STATUS_HYPERHEURISTIC_DATA_NOT_FOUND:
+        return "hyperheuristic data not found";
     default:
         return "unknown status";
     }

--- a/c_api/src/mqlib_c_api.cpp
+++ b/c_api/src/mqlib_c_api.cpp
@@ -1,0 +1,387 @@
+#include "mqlib_c_api.h"
+
+#include <cerrno>
+#include <cmath>
+#include <cstdlib>
+#include <cstring>
+#include <exception>
+#include <limits>
+#include <memory>
+#include <sstream>
+#include <string>
+#include <utility>
+#include <vector>
+
+#include "heuristics/heuristic_factory.h"
+#include "heuristics/maxcut/hyperheuristic.h"
+#include "heuristics/qubo/qubo_simple_solution.h"
+#include "problem/max_cut_instance.h"
+#include "problem/qubo_instance.h"
+
+namespace {
+
+bool has_text(const char *value) {
+    return value != NULL && value[0] != '\0';
+}
+
+bool parse_double_token(const std::string &text, double *value) {
+    char *end = NULL;
+    errno = 0;
+    const double parsed = std::strtod(text.c_str(), &end);
+    if (end == text.c_str() || *end != '\0' || errno == ERANGE) {
+        return false;
+    }
+    *value = parsed;
+    return true;
+}
+
+bool parse_history(
+    const std::string &text,
+    std::vector<std::pair<double, double> > *history
+) {
+    history->clear();
+    if (text.size() < 2 || text[0] != '[' || text[text.size() - 1] != ']') {
+        return false;
+    }
+
+    const std::string body = text.substr(1, text.size() - 2);
+    if (body.empty()) {
+        return true;
+    }
+
+    std::stringstream stream(body);
+    std::string item;
+    while (std::getline(stream, item, ';')) {
+        const std::string::size_type separator = item.find(':');
+        if (separator == std::string::npos) {
+            return false;
+        }
+
+        double objective = 0.0;
+        double time = 0.0;
+        if (!parse_double_token(item.substr(0, separator), &objective) ||
+            !parse_double_token(item.substr(separator + 1), &time)) {
+            return false;
+        }
+
+        history->push_back(std::make_pair(objective, time));
+    }
+
+    return true;
+}
+
+int validate_buffers(
+    const MQLibCQUBOInput *input,
+    MQLibCQUBOResult *result,
+    int32_t *solution_capacity,
+    int32_t *selected_capacity
+) {
+    if (input == NULL || result == NULL) {
+        return MQLIB_STATUS_INVALID_ARGUMENT;
+    }
+    if (input->abi_version != MQLIB_C_ABI_VERSION ||
+        result->abi_version != MQLIB_C_ABI_VERSION) {
+        return MQLIB_STATUS_ABI_VERSION_MISMATCH;
+    }
+
+    *solution_capacity = result->solution_length;
+    *selected_capacity = result->selected_heuristic_length;
+    result->solution_length = input->dimension;
+    result->history_length = 0;
+
+    if (input->dimension <= 0 || input->linear == NULL) {
+        return MQLIB_STATUS_INVALID_ARGUMENT;
+    }
+    if (input->quadratic_count < 0 ||
+        input->quadratic_count > std::numeric_limits<int32_t>::max()) {
+        return MQLIB_STATUS_INVALID_ARGUMENT;
+    }
+    if (input->quadratic_count > 0 &&
+        (input->quadratic_i == NULL ||
+         input->quadratic_j == NULL ||
+         input->quadratic_value == NULL)) {
+        return MQLIB_STATUS_INVALID_ARGUMENT;
+    }
+    if (input->index_base != MQLIB_C_INDEX_BASE_ZERO &&
+        input->index_base != MQLIB_C_INDEX_BASE_ONE) {
+        return MQLIB_STATUS_INVALID_ARGUMENT;
+    }
+    if (!std::isfinite(input->runtime_limit_seconds) ||
+        input->runtime_limit_seconds < 0.0) {
+        return MQLIB_STATUS_INVALID_ARGUMENT;
+    }
+    if (input->random_seed < 0 || input->random_seed > 65535) {
+        return MQLIB_STATUS_INVALID_ARGUMENT;
+    }
+
+    if (result->solution == NULL ||
+        *solution_capacity < input->dimension) {
+        return MQLIB_STATUS_BUFFER_TOO_SMALL;
+    }
+    if (*selected_capacity < 0 ||
+        (*selected_capacity > 0 && result->selected_heuristic == NULL)) {
+        return MQLIB_STATUS_INVALID_ARGUMENT;
+    }
+    if (result->history_capacity < 0 ||
+        (result->history_capacity > 0 &&
+         (result->history_objective_values == NULL ||
+          result->history_times_seconds == NULL))) {
+        return MQLIB_STATUS_INVALID_ARGUMENT;
+    }
+
+    return MQLIB_STATUS_OK;
+}
+
+int build_instance_data(
+    const MQLibCQUBOInput *input,
+    std::vector<double> *linear,
+    std::vector<Instance::InstanceTuple> *quadratic
+) {
+    linear->assign(input->linear, input->linear + input->dimension);
+    for (std::vector<double>::const_iterator iter = linear->begin();
+         iter != linear->end();
+         ++iter) {
+        if (!std::isfinite(*iter)) {
+            return MQLIB_STATUS_INVALID_ARGUMENT;
+        }
+    }
+
+    quadratic->clear();
+    quadratic->reserve(static_cast<size_t>(input->quadratic_count));
+
+    const int32_t lower = input->index_base;
+    const int32_t upper = input->index_base + input->dimension - 1;
+    for (int64_t k = 0; k < input->quadratic_count; ++k) {
+        const int32_t i = input->quadratic_i[k];
+        const int32_t j = input->quadratic_j[k];
+        const double value = input->quadratic_value[k];
+        if (i < lower || i > upper || j < lower || j > upper ||
+            i == j || !std::isfinite(value)) {
+            return MQLIB_STATUS_INVALID_ARGUMENT;
+        }
+
+        const int first = static_cast<int>(i - input->index_base + 1);
+        const int second = static_cast<int>(j - input->index_base + 1);
+        quadratic->push_back(
+            Instance::InstanceTuple(std::make_pair(first, second), value)
+        );
+    }
+
+    return MQLIB_STATUS_OK;
+}
+
+int copy_selected_heuristic(
+    const std::string &selected,
+    int32_t selected_capacity,
+    MQLibCQUBOResult *result
+) {
+    const int32_t required =
+        static_cast<int32_t>(selected.size()) + static_cast<int32_t>(1);
+    result->selected_heuristic_length = required;
+
+    if (selected_capacity == 0 || result->selected_heuristic == NULL) {
+        return MQLIB_STATUS_OK;
+    }
+    if (selected_capacity < required) {
+        return MQLIB_STATUS_BUFFER_TOO_SMALL;
+    }
+
+    std::memcpy(
+        result->selected_heuristic,
+        selected.c_str(),
+        static_cast<size_t>(required)
+    );
+    return MQLIB_STATUS_OK;
+}
+
+int copy_history(
+    const std::vector<std::pair<double, double> > &history,
+    MQLibCQUBOResult *result
+) {
+    result->history_length = static_cast<int32_t>(history.size());
+
+    if (result->history_capacity == 0) {
+        return MQLIB_STATUS_OK;
+    }
+
+    const int32_t to_copy = std::min(
+        result->history_capacity,
+        result->history_length
+    );
+    for (int32_t k = 0; k < to_copy; ++k) {
+        result->history_objective_values[k] = history[static_cast<size_t>(k)].first;
+        result->history_times_seconds[k] = history[static_cast<size_t>(k)].second;
+    }
+
+    if (result->history_capacity < result->history_length) {
+        return MQLIB_STATUS_BUFFER_TOO_SMALL;
+    }
+
+    return MQLIB_STATUS_OK;
+}
+
+int solve_qubo_impl(
+    const MQLibCQUBOInput *input,
+    MQLibCQUBOResult *result,
+    int32_t selected_capacity
+) {
+    std::vector<double> linear;
+    std::vector<Instance::InstanceTuple> quadratic;
+    int status = build_instance_data(input, &linear, &quadratic);
+    if (status != MQLIB_STATUS_OK) {
+        return status;
+    }
+
+    std::srand(static_cast<unsigned int>(input->random_seed));
+
+    QUBOInstance qi(quadratic, linear, static_cast<int>(input->dimension));
+    HeuristicFactory factory;
+    std::unique_ptr<MaxCutInstance> mi;
+    std::unique_ptr<MaxCutHeuristic> maxcut_heuristic;
+    std::unique_ptr<QUBOHeuristic> qubo_heuristic;
+    Heuristic *heuristic = NULL;
+    std::string selected;
+    const bool validation = false;
+
+    if (has_text(input->heuristic)) {
+        const std::string requested(input->heuristic);
+        if (factory.ValidQUBOHeuristicCode(requested)) {
+            qubo_heuristic.reset(factory.RunQUBOHeuristic(
+                requested,
+                qi,
+                input->runtime_limit_seconds,
+                validation,
+                NULL
+            ));
+            heuristic = qubo_heuristic.get();
+            selected = requested;
+        } else if (factory.ValidMaxCutHeuristicCode(requested)) {
+            mi.reset(new MaxCutInstance(qi));
+            maxcut_heuristic.reset(factory.RunMaxCutHeuristic(
+                requested,
+                *mi,
+                input->runtime_limit_seconds,
+                validation,
+                NULL
+            ));
+            heuristic = maxcut_heuristic.get();
+            selected = requested;
+        } else {
+            return MQLIB_STATUS_INVALID_HEURISTIC;
+        }
+    } else {
+        mi.reset(new MaxCutInstance(qi));
+        std::string hyperheuristic_choice;
+        maxcut_heuristic.reset(new MaxCutHyperheuristic(
+            *mi,
+            input->runtime_limit_seconds,
+            validation,
+            NULL,
+            static_cast<int>(input->random_seed),
+            &hyperheuristic_choice
+        ));
+        heuristic = maxcut_heuristic.get();
+        selected = "HH_" + hyperheuristic_choice;
+    }
+
+    if (heuristic == NULL) {
+        return MQLIB_STATUS_INTERNAL_ERROR;
+    }
+
+    result->runtime_seconds = heuristic->Runtime();
+
+    std::vector<int> assignments;
+    if (qubo_heuristic.get() != NULL) {
+        const QUBOSimpleSolution &solution = qubo_heuristic->get_best_solution();
+        assignments = solution.get_assignments();
+        result->objective_value = solution.get_weight();
+    } else {
+        QUBOSimpleSolution solution(
+            maxcut_heuristic->get_best_solution(),
+            qi,
+            NULL
+        );
+        assignments = solution.get_assignments();
+        result->objective_value = solution.get_weight();
+    }
+
+    if (assignments.size() != static_cast<size_t>(input->dimension)) {
+        return MQLIB_STATUS_INTERNAL_ERROR;
+    }
+    for (int32_t k = 0; k < input->dimension; ++k) {
+        result->solution[k] = assignments[static_cast<size_t>(k)];
+    }
+
+    std::vector<std::pair<double, double> > history;
+    if (!parse_history(heuristic->History(), &history)) {
+        return MQLIB_STATUS_INTERNAL_ERROR;
+    }
+
+    const int selected_status =
+        copy_selected_heuristic(selected, selected_capacity, result);
+    const int history_status = copy_history(history, result);
+    if (selected_status != MQLIB_STATUS_OK) {
+        return selected_status;
+    }
+    if (history_status != MQLIB_STATUS_OK) {
+        return history_status;
+    }
+
+    return MQLIB_STATUS_OK;
+}
+
+}  // namespace
+
+extern "C" MQLIB_C_API int mqlib_c_abi_version(void) {
+    return static_cast<int>(MQLIB_C_ABI_VERSION);
+}
+
+extern "C" MQLIB_C_API const char *mqlib_c_status_message(int status) {
+    switch (status) {
+    case MQLIB_STATUS_OK:
+        return "ok";
+    case MQLIB_STATUS_ABI_VERSION_MISMATCH:
+        return "ABI version mismatch";
+    case MQLIB_STATUS_INVALID_ARGUMENT:
+        return "invalid argument";
+    case MQLIB_STATUS_INVALID_HEURISTIC:
+        return "invalid heuristic";
+    case MQLIB_STATUS_BUFFER_TOO_SMALL:
+        return "buffer too small";
+    case MQLIB_STATUS_ALLOCATION_FAILED:
+        return "allocation failed";
+    case MQLIB_STATUS_INTERNAL_ERROR:
+        return "internal error";
+    default:
+        return "unknown status";
+    }
+}
+
+extern "C" MQLIB_C_API int mqlib_solve_qubo(
+    const MQLibCQUBOInput *input,
+    MQLibCQUBOResult *result
+) {
+    int32_t solution_capacity = 0;
+    int32_t selected_capacity = 0;
+    int status = validate_buffers(
+        input,
+        result,
+        &solution_capacity,
+        &selected_capacity
+    );
+    if (status != MQLIB_STATUS_OK) {
+        return status;
+    }
+
+    (void)solution_capacity;
+
+    try {
+        return solve_qubo_impl(input, result, selected_capacity);
+    } catch (const std::bad_alloc &) {
+        return MQLIB_STATUS_ALLOCATION_FAILED;
+    } catch (const std::exception &) {
+        return MQLIB_STATUS_INTERNAL_ERROR;
+    } catch (...) {
+        return MQLIB_STATUS_INTERNAL_ERROR;
+    }
+}

--- a/c_api/src/mqlib_c_api.cpp
+++ b/c_api/src/mqlib_c_api.cpp
@@ -108,6 +108,11 @@ double elapsed_seconds(const struct timeval &start) {
         0.000001 * (end.tv_usec - start.tv_usec);
 }
 
+double remaining_runtime_limit(double runtime_limit_seconds, double elapsed) {
+    const double remaining = runtime_limit_seconds - elapsed;
+    return remaining > 0.0 ? remaining : 0.0;
+}
+
 void update_hyperheuristic_choice(
     const std::string &code,
     HyperheuristicProblem problem,
@@ -367,6 +372,7 @@ int solve_qubo_impl(
     std::string selected;
     const bool validation = false;
     bool qubo_solution_uses_original_instance = true;
+    double hyperheuristic_selection_seconds = 0.0;
     double hyperheuristic_runtime_seconds = -1.0;
 
     if (has_text(input->heuristic)) {
@@ -411,12 +417,19 @@ int solve_qubo_impl(
             return status;
         }
 
+        hyperheuristic_selection_seconds =
+            elapsed_seconds(hyperheuristic_start);
+        const double selected_runtime_limit = remaining_runtime_limit(
+            input->runtime_limit_seconds,
+            hyperheuristic_selection_seconds
+        );
+
         std::srand(static_cast<unsigned int>(input->random_seed));
         if (choice.problem == HYPERHEURISTIC_MAXCUT) {
             maxcut_heuristic.reset(factory.RunMaxCutHeuristic(
                 choice.code,
                 *mi,
-                input->runtime_limit_seconds,
+                selected_runtime_limit,
                 validation,
                 NULL
             ));
@@ -426,7 +439,7 @@ int solve_qubo_impl(
             qubo_heuristic.reset(factory.RunQUBOHeuristic(
                 choice.code,
                 *hyperheuristic_qi,
-                input->runtime_limit_seconds,
+                selected_runtime_limit,
                 validation,
                 NULL
             ));
@@ -478,6 +491,16 @@ int solve_qubo_impl(
     std::vector<std::pair<double, double> > history;
     if (!parse_history(heuristic->History(), &history)) {
         return MQLIB_STATUS_INTERNAL_ERROR;
+    }
+    if (hyperheuristic_runtime_seconds >= 0.0) {
+        for (std::vector<std::pair<double, double> >::iterator iter =
+                 history.begin();
+             iter != history.end();
+             ++iter) {
+            if (iter != history.begin()) {
+                iter->second += hyperheuristic_selection_seconds;
+            }
+        }
     }
 
     const int selected_status =

--- a/c_api/src/mqlib_c_api.cpp
+++ b/c_api/src/mqlib_c_api.cpp
@@ -10,6 +10,7 @@
 #include <memory>
 #include <sstream>
 #include <string>
+#include <sys/time.h>
 #include <utility>
 #include <vector>
 
@@ -98,6 +99,13 @@ std::string model_path(const std::string &data_dir, const std::string &code) {
 bool file_exists(const std::string &path) {
     std::ifstream file(path.c_str());
     return file.good();
+}
+
+double elapsed_seconds(const struct timeval &start) {
+    struct timeval end;
+    gettimeofday(&end, 0);
+    return (end.tv_sec - start.tv_sec) +
+        0.000001 * (end.tv_usec - start.tv_usec);
 }
 
 void update_hyperheuristic_choice(
@@ -359,6 +367,7 @@ int solve_qubo_impl(
     std::string selected;
     const bool validation = false;
     bool qubo_solution_uses_original_instance = true;
+    double hyperheuristic_runtime_seconds = -1.0;
 
     if (has_text(input->heuristic)) {
         const std::string requested(input->heuristic);
@@ -388,6 +397,9 @@ int solve_qubo_impl(
         }
     } else {
         mi.reset(new MaxCutInstance(qi));
+        struct timeval hyperheuristic_start;
+        gettimeofday(&hyperheuristic_start, 0);
+
         HyperheuristicChoice choice;
         status = select_hyperheuristic(
             &factory,
@@ -422,13 +434,17 @@ int solve_qubo_impl(
             qubo_solution_uses_original_instance = false;
         }
         selected = "HH_" + choice.code;
+        hyperheuristic_runtime_seconds =
+            elapsed_seconds(hyperheuristic_start);
     }
 
     if (heuristic == NULL) {
         return MQLIB_STATUS_INTERNAL_ERROR;
     }
 
-    result->runtime_seconds = heuristic->Runtime();
+    result->runtime_seconds = hyperheuristic_runtime_seconds >= 0.0 ?
+        hyperheuristic_runtime_seconds :
+        heuristic->Runtime();
 
     std::vector<int> assignments;
     if (qubo_heuristic.get() != NULL) {

--- a/test/c_api_smoke.c
+++ b/test/c_api_smoke.c
@@ -1,5 +1,6 @@
 #include <stdio.h>
 #include <string.h>
+#include <time.h>
 
 #include "mqlib_c_api.h"
 
@@ -37,7 +38,12 @@ static void init_result(MQLibCQUBOResult *result, int32_t *solution, char *selec
     result->history_length = 0;
 }
 
-static int run_success_case(const char *heuristic, const char *hhdata_dir, const char *expected_prefix) {
+static int run_success_case(
+    const char *heuristic,
+    const char *hhdata_dir,
+    const char *expected_prefix,
+    int require_full_elapsed_runtime
+) {
     MQLibCQUBOInput input;
     MQLibCQUBOResult result;
     int32_t solution[3] = {0, 0, 0};
@@ -46,7 +52,9 @@ static int run_success_case(const char *heuristic, const char *hhdata_dir, const
     init_input(&input, heuristic, hhdata_dir);
     init_result(&result, solution, selected_heuristic);
 
+    const clock_t start = clock();
     const int status = mqlib_solve_qubo(&input, &result);
+    const clock_t end = clock();
     if (status != MQLIB_STATUS_OK) {
         fprintf(stderr, "expected success, got %s\n", mqlib_c_status_message(status));
         return 1;
@@ -58,6 +66,25 @@ static int run_success_case(const char *heuristic, const char *hhdata_dir, const
     if (result.solution_length != 3) {
         fprintf(stderr, "unexpected solution length: %d\n", result.solution_length);
         return 1;
+    }
+    if (result.runtime_seconds <= 0.0) {
+        fprintf(stderr, "expected positive runtime, got %.15g\n", result.runtime_seconds);
+        return 1;
+    }
+    if (require_full_elapsed_runtime &&
+        start != (clock_t)-1 &&
+        end != (clock_t)-1) {
+        const double elapsed =
+            ((double)(end - start)) / ((double)CLOCKS_PER_SEC);
+        if (result.runtime_seconds + 0.02 < elapsed) {
+            fprintf(
+                stderr,
+                "runtime %.15g omits elapsed hyperheuristic work %.15g\n",
+                result.runtime_seconds,
+                elapsed
+            );
+            return 1;
+        }
     }
     return 0;
 }
@@ -85,13 +112,13 @@ int main(int argc, char **argv) {
         return 2;
     }
 
-    if (run_success_case("ALKHAMIS1998", NULL, "ALKHAMIS1998") != 0) {
+    if (run_success_case("ALKHAMIS1998", NULL, "ALKHAMIS1998", 0) != 0) {
         return 1;
     }
     if (run_missing_hhdata_case() != 0) {
         return 1;
     }
-    if (run_success_case(NULL, argv[1], "HH_") != 0) {
+    if (run_success_case(NULL, argv[1], "HH_", 1) != 0) {
         return 1;
     }
 

--- a/test/c_api_smoke.c
+++ b/test/c_api_smoke.c
@@ -125,7 +125,7 @@ static int run_hyperheuristic_budget_case(const char *hhdata_dir) {
     char selected_heuristic[64] = {0};
     double history_values[32] = {0.0};
     double history_times[32] = {0.0};
-    const double runtime_limit_seconds = 0.75;
+    const double runtime_limit_seconds = 1.50;
 
     init_input(&input, NULL, hhdata_dir, runtime_limit_seconds);
     init_result(

--- a/test/c_api_smoke.c
+++ b/test/c_api_smoke.c
@@ -1,0 +1,99 @@
+#include <stdio.h>
+#include <string.h>
+
+#include "mqlib_c_api.h"
+
+static void init_input(MQLibCQUBOInput *input, const char *heuristic, const char *hhdata_dir) {
+    static const double linear[3] = {5.0, 3.0, 1.0};
+    static const int32_t quadratic_i[2] = {0, 1};
+    static const int32_t quadratic_j[2] = {1, 2};
+    static const double quadratic_value[2] = {-6.0, -1.0};
+
+    input->abi_version = MQLIB_C_ABI_VERSION;
+    input->dimension = 3;
+    input->linear = linear;
+    input->quadratic_count = 2;
+    input->quadratic_i = quadratic_i;
+    input->quadratic_j = quadratic_j;
+    input->quadratic_value = quadratic_value;
+    input->index_base = MQLIB_C_INDEX_BASE_ZERO;
+    input->heuristic = heuristic;
+    input->runtime_limit_seconds = 0.01;
+    input->random_seed = 1234;
+    input->hyperheuristic_data_dir = hhdata_dir;
+}
+
+static void init_result(MQLibCQUBOResult *result, int32_t *solution, char *selected_heuristic) {
+    result->abi_version = MQLIB_C_ABI_VERSION;
+    result->objective_value = 0.0;
+    result->runtime_seconds = 0.0;
+    result->solution = solution;
+    result->solution_length = 3;
+    result->selected_heuristic = selected_heuristic;
+    result->selected_heuristic_length = 64;
+    result->history_objective_values = NULL;
+    result->history_times_seconds = NULL;
+    result->history_capacity = 0;
+    result->history_length = 0;
+}
+
+static int run_success_case(const char *heuristic, const char *hhdata_dir, const char *expected_prefix) {
+    MQLibCQUBOInput input;
+    MQLibCQUBOResult result;
+    int32_t solution[3] = {0, 0, 0};
+    char selected_heuristic[64] = {0};
+
+    init_input(&input, heuristic, hhdata_dir);
+    init_result(&result, solution, selected_heuristic);
+
+    const int status = mqlib_solve_qubo(&input, &result);
+    if (status != MQLIB_STATUS_OK) {
+        fprintf(stderr, "expected success, got %s\n", mqlib_c_status_message(status));
+        return 1;
+    }
+    if (strncmp(result.selected_heuristic, expected_prefix, strlen(expected_prefix)) != 0) {
+        fprintf(stderr, "unexpected selected heuristic: %s\n", result.selected_heuristic);
+        return 1;
+    }
+    if (result.solution_length != 3) {
+        fprintf(stderr, "unexpected solution length: %d\n", result.solution_length);
+        return 1;
+    }
+    return 0;
+}
+
+static int run_missing_hhdata_case(void) {
+    MQLibCQUBOInput input;
+    MQLibCQUBOResult result;
+    int32_t solution[3] = {0, 0, 0};
+    char selected_heuristic[64] = {0};
+
+    init_input(&input, NULL, NULL);
+    init_result(&result, solution, selected_heuristic);
+
+    const int status = mqlib_solve_qubo(&input, &result);
+    if (status != MQLIB_STATUS_HYPERHEURISTIC_DATA_NOT_FOUND) {
+        fprintf(stderr, "expected missing hyperheuristic data, got %s\n", mqlib_c_status_message(status));
+        return 1;
+    }
+    return 0;
+}
+
+int main(int argc, char **argv) {
+    if (argc != 2) {
+        fprintf(stderr, "usage: %s /path/to/MQLib/hhdata\n", argv[0]);
+        return 2;
+    }
+
+    if (run_success_case("ALKHAMIS1998", NULL, "ALKHAMIS1998") != 0) {
+        return 1;
+    }
+    if (run_missing_hhdata_case() != 0) {
+        return 1;
+    }
+    if (run_success_case(NULL, argv[1], "HH_") != 0) {
+        return 1;
+    }
+
+    return 0;
+}

--- a/test/c_api_smoke.c
+++ b/test/c_api_smoke.c
@@ -4,7 +4,12 @@
 
 #include "mqlib_c_api.h"
 
-static void init_input(MQLibCQUBOInput *input, const char *heuristic, const char *hhdata_dir) {
+static void init_input(
+    MQLibCQUBOInput *input,
+    const char *heuristic,
+    const char *hhdata_dir,
+    double runtime_limit_seconds
+) {
     static const double linear[3] = {5.0, 3.0, 1.0};
     static const int32_t quadratic_i[2] = {0, 1};
     static const int32_t quadratic_j[2] = {1, 2};
@@ -19,12 +24,19 @@ static void init_input(MQLibCQUBOInput *input, const char *heuristic, const char
     input->quadratic_value = quadratic_value;
     input->index_base = MQLIB_C_INDEX_BASE_ZERO;
     input->heuristic = heuristic;
-    input->runtime_limit_seconds = 0.01;
+    input->runtime_limit_seconds = runtime_limit_seconds;
     input->random_seed = 1234;
     input->hyperheuristic_data_dir = hhdata_dir;
 }
 
-static void init_result(MQLibCQUBOResult *result, int32_t *solution, char *selected_heuristic) {
+static void init_result(
+    MQLibCQUBOResult *result,
+    int32_t *solution,
+    char *selected_heuristic,
+    double *history_values,
+    double *history_times,
+    int32_t history_capacity
+) {
     result->abi_version = MQLIB_C_ABI_VERSION;
     result->objective_value = 0.0;
     result->runtime_seconds = 0.0;
@@ -32,9 +44,9 @@ static void init_result(MQLibCQUBOResult *result, int32_t *solution, char *selec
     result->solution_length = 3;
     result->selected_heuristic = selected_heuristic;
     result->selected_heuristic_length = 64;
-    result->history_objective_values = NULL;
-    result->history_times_seconds = NULL;
-    result->history_capacity = 0;
+    result->history_objective_values = history_values;
+    result->history_times_seconds = history_times;
+    result->history_capacity = history_capacity;
     result->history_length = 0;
 }
 
@@ -49,8 +61,8 @@ static int run_success_case(
     int32_t solution[3] = {0, 0, 0};
     char selected_heuristic[64] = {0};
 
-    init_input(&input, heuristic, hhdata_dir);
-    init_result(&result, solution, selected_heuristic);
+    init_input(&input, heuristic, hhdata_dir, 0.01);
+    init_result(&result, solution, selected_heuristic, NULL, NULL, 0);
 
     const clock_t start = clock();
     const int status = mqlib_solve_qubo(&input, &result);
@@ -95,14 +107,72 @@ static int run_missing_hhdata_case(void) {
     int32_t solution[3] = {0, 0, 0};
     char selected_heuristic[64] = {0};
 
-    init_input(&input, NULL, NULL);
-    init_result(&result, solution, selected_heuristic);
+    init_input(&input, NULL, NULL, 0.01);
+    init_result(&result, solution, selected_heuristic, NULL, NULL, 0);
 
     const int status = mqlib_solve_qubo(&input, &result);
     if (status != MQLIB_STATUS_HYPERHEURISTIC_DATA_NOT_FOUND) {
         fprintf(stderr, "expected missing hyperheuristic data, got %s\n", mqlib_c_status_message(status));
         return 1;
     }
+    return 0;
+}
+
+static int run_hyperheuristic_budget_case(const char *hhdata_dir) {
+    MQLibCQUBOInput input;
+    MQLibCQUBOResult result;
+    int32_t solution[3] = {0, 0, 0};
+    char selected_heuristic[64] = {0};
+    double history_values[32] = {0.0};
+    double history_times[32] = {0.0};
+    const double runtime_limit_seconds = 0.75;
+
+    init_input(&input, NULL, hhdata_dir, runtime_limit_seconds);
+    init_result(
+        &result,
+        solution,
+        selected_heuristic,
+        history_values,
+        history_times,
+        32
+    );
+
+    const int status = mqlib_solve_qubo(&input, &result);
+    if (status != MQLIB_STATUS_OK) {
+        fprintf(stderr, "expected success, got %s\n", mqlib_c_status_message(status));
+        return 1;
+    }
+    if (result.runtime_seconds > runtime_limit_seconds + 0.30) {
+        fprintf(
+            stderr,
+            "hyperheuristic runtime %.15g exceeded budget %.15g\n",
+            result.runtime_seconds,
+            runtime_limit_seconds
+        );
+        return 1;
+    }
+    if (result.history_length < 2) {
+        fprintf(stderr, "expected hyperheuristic history to include an improvement\n");
+        return 1;
+    }
+    if (history_times[1] < 0.10) {
+        fprintf(
+            stderr,
+            "history time %.15g does not include hyperheuristic selection time\n",
+            history_times[1]
+        );
+        return 1;
+    }
+    if (history_times[1] > result.runtime_seconds + 0.02) {
+        fprintf(
+            stderr,
+            "history time %.15g exceeded reported runtime %.15g\n",
+            history_times[1],
+            result.runtime_seconds
+        );
+        return 1;
+    }
+    (void)history_values;
     return 0;
 }
 
@@ -119,6 +189,9 @@ int main(int argc, char **argv) {
         return 1;
     }
     if (run_success_case(NULL, argv[1], "HH_", 1) != 0) {
+        return 1;
+    }
+    if (run_hyperheuristic_budget_case(argv[1]) != 0) {
         return 1;
     }
 

--- a/test/native_c_api_smoke.sh
+++ b/test/native_c_api_smoke.sh
@@ -4,13 +4,21 @@ set -euo pipefail
 ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
 BUILD_DIR="$(mktemp -d)"
 trap 'rm -rf "$BUILD_DIR"' EXIT
+DEFAULT_MQLIB_UPSTREAM_REF="585496274af5abb0849d0d47e135496b4688680b"
+MQLIB_UPSTREAM_REF="${MQLIB_UPSTREAM_REF:-$DEFAULT_MQLIB_UPSTREAM_REF}"
 
 if [[ -n "${MQLIB_UPSTREAM_DIR:-}" ]]; then
     UPSTREAM_DIR="$MQLIB_UPSTREAM_DIR"
 else
     UPSTREAM_DIR="$BUILD_DIR/MQLib-upstream"
     git clone --depth 1 https://github.com/MQLib/MQLib.git "$UPSTREAM_DIR"
+    if [[ "$MQLIB_UPSTREAM_REF" != "HEAD" ]]; then
+        git -C "$UPSTREAM_DIR" fetch --depth 1 origin "$MQLIB_UPSTREAM_REF"
+        git -C "$UPSTREAM_DIR" checkout --detach FETCH_HEAD
+    fi
 fi
+
+echo "Using upstream MQLib $(git -C "$UPSTREAM_DIR" rev-parse --short HEAD)"
 
 if [[ ! -d "$UPSTREAM_DIR/include" || ! -d "$UPSTREAM_DIR/hhdata" ]]; then
     echo "MQLIB_UPSTREAM_DIR must point to an upstream MQLib checkout with include/ and hhdata/" >&2

--- a/test/native_c_api_smoke.sh
+++ b/test/native_c_api_smoke.sh
@@ -1,0 +1,54 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+BUILD_DIR="$(mktemp -d)"
+trap 'rm -rf "$BUILD_DIR"' EXIT
+
+if [[ -n "${MQLIB_UPSTREAM_DIR:-}" ]]; then
+    UPSTREAM_DIR="$MQLIB_UPSTREAM_DIR"
+else
+    UPSTREAM_DIR="$BUILD_DIR/MQLib-upstream"
+    git clone --depth 1 https://github.com/MQLib/MQLib.git "$UPSTREAM_DIR"
+fi
+
+if [[ ! -d "$UPSTREAM_DIR/include" || ! -d "$UPSTREAM_DIR/hhdata" ]]; then
+    echo "MQLIB_UPSTREAM_DIR must point to an upstream MQLib checkout with include/ and hhdata/" >&2
+    exit 2
+fi
+
+mapfile -t UPSTREAM_SOURCES < <(find "$UPSTREAM_DIR/src" -name '*.cpp' ! -name main.cpp | sort)
+
+c++ -std=c++11 -fPIC \
+    -I"$ROOT/c_api/include" \
+    -I"$UPSTREAM_DIR/include" \
+    "${UPSTREAM_SOURCES[@]}" \
+    "$ROOT/c_api/src/mqlib_c_api.cpp" \
+    -shared \
+    -o "$BUILD_DIR/libmqlib_c_api.so" \
+    -lm
+
+cc -std=c99 \
+    -I"$ROOT/c_api/include" \
+    "$ROOT/c_api/examples/solve_qubo.c" \
+    -L"$BUILD_DIR" \
+    -lmqlib_c_api \
+    -Wl,-rpath,"$BUILD_DIR" \
+    -o "$BUILD_DIR/solve_qubo"
+
+cc -std=c99 \
+    -I"$ROOT/c_api/include" \
+    "$ROOT/test/c_api_smoke.c" \
+    -L"$BUILD_DIR" \
+    -lmqlib_c_api \
+    -Wl,-rpath,"$BUILD_DIR" \
+    -o "$BUILD_DIR/c_api_smoke"
+
+RUN_DIR="$BUILD_DIR/run-without-hhdata"
+mkdir -p "$RUN_DIR"
+
+(
+    cd "$RUN_DIR"
+    "$BUILD_DIR/solve_qubo" "$UPSTREAM_DIR/hhdata"
+    "$BUILD_DIR/c_api_smoke" "$UPSTREAM_DIR/hhdata"
+)

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -1,7 +1,79 @@
+import Test
 import MQLib
 import MQLib: MOI, QUBODrivers
 
-QUBODrivers.test(MQLib.Optimizer) do model
-    MOI.set(model, MOI.Silent(), true)
-    MOI.set(model, MQLib.Heuristic(), first(MQLib.heuristics()))
+function first_available_tool(names::Vector{String})
+    for name in names
+        path = Sys.which(name)
+        if !isnothing(path)
+            return path
+        end
+    end
+
+    return nothing
+end
+
+Test.@testset "QUBODrivers" begin
+    QUBODrivers.test(MQLib.Optimizer) do model
+        MOI.set(model, MOI.Silent(), true)
+        MOI.set(model, MQLib.Heuristic(), first(MQLib.heuristics()))
+    end
+end
+
+Test.@testset "C ABI contract" begin
+    root = dirname(dirname(@__FILE__))
+    include_dir = joinpath(root, "c_api", "include")
+    header = joinpath(include_dir, "mqlib_c_api.h")
+    source = joinpath(root, "c_api", "src", "mqlib_c_api.cpp")
+
+    Test.@test isfile(header)
+    Test.@test isfile(source)
+
+    header_text = read(header, String)
+    for symbol in (
+        "MQLIB_C_ABI_VERSION",
+        "MQLibCQUBOInput",
+        "MQLibCQUBOResult",
+        "mqlib_solve_qubo",
+        "mqlib_c_status_message",
+    )
+        Test.@test occursin(symbol, header_text)
+    end
+
+    cc = first_available_tool(["cc", "gcc", "clang"])
+    if isnothing(cc)
+        @info "Skipping C ABI header syntax check because no C compiler was found"
+    else
+        mktempdir() do dir
+            check = joinpath(dir, "check_mqlib_c_api.c")
+            write(
+                check,
+                """
+                #include "mqlib_c_api.h"
+
+                int main(void) {
+                    MQLibCQUBOInput input;
+                    MQLibCQUBOResult result;
+                    (void)input;
+                    (void)result;
+                    return mqlib_c_abi_version() == MQLIB_C_ABI_VERSION ? 0 : 0;
+                }
+                """,
+            )
+            Test.@test success(`$cc -std=c99 -I$include_dir -fsyntax-only $check`)
+        end
+    end
+
+    upstream_dir = get(ENV, "MQLIB_UPSTREAM_DIR", "")
+    cxx = first_available_tool(["c++", "g++", "clang++"])
+    if isempty(upstream_dir) || !isdir(joinpath(upstream_dir, "include"))
+        @info "Skipping C ABI source syntax check because MQLIB_UPSTREAM_DIR is not set"
+    elseif isnothing(cxx)
+        @info "Skipping C ABI source syntax check because no C++ compiler was found"
+    else
+        upstream_include = joinpath(upstream_dir, "include")
+        Test.@test success(
+            `$cxx -std=c++11 -I$include_dir -I$upstream_include -fsyntax-only $source`,
+        )
+    end
 end

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -36,6 +36,7 @@ Test.@testset "C ABI contract" begin
         "MQLibCQUBOResult",
         "mqlib_solve_qubo",
         "mqlib_c_status_message",
+        "MQLIB_STATUS_HYPERHEURISTIC_DATA_NOT_FOUND",
     )
         Test.@test occursin(symbol, header_text)
     end


### PR DESCRIPTION
## Summary

- Adds a documented C ABI for solving QUBO instances through upstream MQLib internals without invoking the CLI executable.
- Adds a C++ wrapper implementation that accepts caller-owned plain arrays, validates ABI inputs, runs explicit heuristics or the hyperheuristic path, and returns stable status codes, objective, solution, runtime, selected heuristic, and optional history data.
- Adds a small native C example plus Julia tests for the ABI contract and optional upstream-backed syntax checking.

## Tests run

- `cc -std=c99 -Ic_api/include -fsyntax-only c_api/examples/solve_qubo.c` - passed.
- `c++ -std=c++11 -Ic_api/include -I/tmp/MQLib-upstream/include -fsyntax-only c_api/src/mqlib_c_api.cpp` - passed.
- `c++ -std=c++11 -fPIC -Ic_api/include -I/tmp/MQLib-upstream/include $(find /tmp/MQLib-upstream/src -name '*.cpp' ! -name main.cpp) c_api/src/mqlib_c_api.cpp -shared -o /tmp/mqlib-c-api-build/libmqlib_c_api.so -lm` - passed.
- `cc -std=c99 -Ic_api/include c_api/examples/solve_qubo.c -L/tmp/mqlib-c-api-build -lmqlib_c_api -Wl,-rpath,/tmp/mqlib-c-api-build -o /tmp/mqlib-c-api-build/solve_qubo` - passed.
- `/tmp/mqlib-c-api-build/solve_qubo` - passed:
  - `ALKHAMIS1998 objective 6 solution 1 0 1 runtime 0.010025 seconds`
  - `HH_BEASLEY1998TS objective 0 solution 0 0 0 runtime 0.507517 seconds`
- `MQLIB_UPSTREAM_DIR=/tmp/MQLib-upstream julia +1.12 --project=. test/runtests.jl` - passed: QUBODrivers 124/124, C ABI contract 9/9.
- `julia +1.12 --project=. test/runtests.jl` - passed: QUBODrivers 124/124, C ABI contract 8/8; upstream source syntax check skipped because `MQLIB_UPSTREAM_DIR` was not set.

## Notes

- `MQLIB_UPSTREAM_DIR=/tmp/MQLib-upstream julia +1.12 --project=. -e 'import Pkg; Pkg.test()'` did not execute tests locally because the current manifest fixes local `QUBOTools` at 0.12.0 while `Project.toml` restricts `QUBOTools` to `0.10.1, 0.11`.
- The Julia wrapper still uses the executable path. Using this ABI from Julia is the follow-up shared-library integration work.

Closes #9
