### PR TITLE
Use MQLib shared library when available

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@
 - Added a Julia `ccall` solve path that uses `MQLib_jll.libmqlib_c_api`.
 - Required `MQLib_jll` 0.1.2 or newer so the shared-library product is available from the published JLL.
 - Kept the existing executable-backed solve path as a defensive fallback if the C ABI library is unavailable.
+- Used the executable fallback for default hyperheuristic solves when the JLL artifact does not include hyperheuristic model files.
 - Updated the BinaryBuilder recipe sketch to install MQLib hyperheuristic model files under `share/mqlib/hhdata`.
 
 ## v0.5.0 - 2026-05-27

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,11 @@
 # Changelog
 
+## Unreleased
+
+- Added a Julia `ccall` solve path that uses `MQLib_jll.libmqlib_c_api` when the shared library product is available.
+- Kept the existing executable-backed solve path as a fallback for current `MQLib_jll` builds that do not yet export the C ABI library.
+- Updated the BinaryBuilder recipe sketch to install MQLib hyperheuristic model files under `share/mqlib/hhdata`.
+
 ## v0.5.0 - 2026-05-27
 
 - Raised the Julia compatibility floor from 1.9 to 1.10.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,8 +2,9 @@
 
 ## Unreleased
 
-- Added a Julia `ccall` solve path that uses `MQLib_jll.libmqlib_c_api` when the shared library product is available.
-- Kept the existing executable-backed solve path as a fallback for current `MQLib_jll` builds that do not yet export the C ABI library.
+- Added a Julia `ccall` solve path that uses `MQLib_jll.libmqlib_c_api`.
+- Required `MQLib_jll` 0.1.2 or newer so the shared-library product is available from the published JLL.
+- Kept the existing executable-backed solve path as a defensive fallback if the C ABI library is unavailable.
 - Updated the BinaryBuilder recipe sketch to install MQLib hyperheuristic model files under `share/mqlib/hhdata`.
 
 ## v0.5.0 - 2026-05-27

--- a/Project.toml
+++ b/Project.toml
@@ -11,7 +11,7 @@ QUBODrivers = "a3f166f7-2cd3-47b6-9e1e-6fbfe0449eb0"
 QUBOTools = "60eb5b62-0a39-4ddc-84c5-97d2adff9319"
 
 [compat]
-MQLib_jll        = "0.1"
+MQLib_jll        = "0.1.2"
 MathOptInterface = "1"
 Printf           = "1"
 QUBOTools        = "0.12"

--- a/README.md
+++ b/README.md
@@ -4,8 +4,9 @@
 
 [MQLib](https://github.com/MQLib/MQLib) wrapper for JuMP.
 
-MQLib.jl uses the shared-library C ABI when `MQLib_jll` provides
-`libmqlib_c_api`. Older JLL builds continue to use the executable-backed path.
+MQLib.jl uses the `libmqlib_c_api` shared-library product provided by
+`MQLib_jll` v0.1.2 and newer. The executable-backed path remains as a
+defensive fallback if the library product is unavailable.
 
 ## Installation
 ```julia

--- a/README.md
+++ b/README.md
@@ -4,6 +4,9 @@
 
 [MQLib](https://github.com/MQLib/MQLib) wrapper for JuMP.
 
+MQLib.jl uses the shared-library C ABI when `MQLib_jll` provides
+`libmqlib_c_api`. Older JLL builds continue to use the executable-backed path.
+
 ## Installation
 ```julia
 julia> import Pkg

--- a/README.md
+++ b/README.md
@@ -6,7 +6,8 @@
 
 MQLib.jl uses the `libmqlib_c_api` shared-library product provided by
 `MQLib_jll` v0.1.2 and newer. The executable-backed path remains as a
-defensive fallback if the library product is unavailable.
+defensive fallback if the library product is unavailable, or if a default
+hyperheuristic solve needs model files that are not packaged in the JLL.
 
 ## Installation
 ```julia

--- a/c_api/README.md
+++ b/c_api/README.md
@@ -4,8 +4,9 @@ This directory defines the native C ABI for solving QUBO instances through
 MQLib without invoking the command-line executable.
 
 The files here are intended to be compiled with the upstream MQLib C++ sources
-and packaged as a shared library by `MQLib_jll`. The Julia wrapper does not call
-this ABI yet; that integration belongs to the follow-up shared-library issue.
+and packaged as a shared library by `MQLib_jll`. The Julia wrapper uses this
+ABI when `MQLib_jll` exports `libmqlib_c_api`; older JLL builds continue to use
+the executable-backed path.
 
 ## API
 
@@ -45,7 +46,8 @@ The `MQLib_jll` build recipe in `jll/build_tarballs.jl` builds the existing
 `MQLib` executable product and a shared library product named
 `libmqlib_c_api`. The library compiles `c_api/src/mqlib_c_api.cpp` with the
 upstream MQLib implementation sources, excluding the upstream executable entry
-point (`src/main.cpp`), and installs this header as `mqlib_c_api.h`.
+point (`src/main.cpp`), installs this header as `mqlib_c_api.h`, and installs
+the hyperheuristic model files under `share/mqlib/hhdata`.
 
 Downstream Julia code should call the library product exported by `MQLib_jll`,
 for example:

--- a/c_api/README.md
+++ b/c_api/README.md
@@ -7,7 +7,8 @@ The files here are intended to be compiled with the upstream MQLib C++ sources
 and packaged as a shared library by `MQLib_jll`. The Julia wrapper uses this
 ABI through the `libmqlib_c_api` product exported by `MQLib_jll` v0.1.2 and
 newer. The executable-backed path remains as a defensive fallback if the library
-product is unavailable.
+product is unavailable, or if a default hyperheuristic solve needs model files
+that are not packaged in the JLL.
 
 ## API
 

--- a/c_api/README.md
+++ b/c_api/README.md
@@ -5,8 +5,9 @@ MQLib without invoking the command-line executable.
 
 The files here are intended to be compiled with the upstream MQLib C++ sources
 and packaged as a shared library by `MQLib_jll`. The Julia wrapper uses this
-ABI when `MQLib_jll` exports `libmqlib_c_api`; older JLL builds continue to use
-the executable-backed path.
+ABI through the `libmqlib_c_api` product exported by `MQLib_jll` v0.1.2 and
+newer. The executable-backed path remains as a defensive fallback if the library
+product is unavailable.
 
 ## API
 

--- a/jll/build_tarballs.jl
+++ b/jll/build_tarballs.jl
@@ -3,7 +3,7 @@
 using BinaryBuilder, Pkg
 
 name = "MQLib"
-version = v"0.1.1"
+version = v"0.1.2"
 
 # Collection of sources required to complete build.
 sources = [
@@ -14,7 +14,7 @@ sources = [
     # Provides the C ABI wrapper that is packaged as libmqlib_c_api.
     GitSource(
         "https://github.com/JuliaQUBO/MQLib.jl.git",
-        "8b491876ef44b663e8fd04a48d262d72e73faff7",
+        "3160500db96ca1a1bb1271897c4141b9124676cf",
     ),
 ]
 
@@ -31,14 +31,17 @@ if [[ ! -f "${MQLIB_JL_SRC}/c_api/src/mqlib_c_api.cpp" ]]; then
     exit 1
 fi
 
+mkdir -p "${bindir}" "${libdir}" "${includedir}" "${datadir}/mqlib/hhdata"
+
 cd "${MQLIB_SRC}"
 make -j${nproc}
 install -Dvm 0755 bin/MQLib "${bindir}/MQLib${exeext}"
 install -Dvm 0644 \
     "${MQLIB_JL_SRC}/c_api/include/mqlib_c_api.h" \
     "${includedir}/mqlib_c_api.h"
+install -vm 0644 hhdata/*.rf "${datadir}/mqlib/hhdata/"
 
-mapfile -t MQLIB_LIBRARY_SOURCES < <(find src -name '*.cpp' ! -name main.cpp | sort)
+MQLIB_LIBRARY_SOURCES="$(find src -name '*.cpp' ! -name main.cpp | sort)"
 
 if [[ "${target}" == *-mingw* ]]; then
     MQLIB_C_API_LIBRARY="${bindir}/libmqlib_c_api.${dlext}"
@@ -64,7 +67,7 @@ fi
     -DMQLIB_C_BUILD_SHARED \
     -Iinclude \
     -I"${MQLIB_JL_SRC}/c_api/include" \
-    "${MQLIB_LIBRARY_SOURCES[@]}" \
+    ${MQLIB_LIBRARY_SOURCES} \
     "${MQLIB_JL_SRC}/c_api/src/mqlib_c_api.cpp" \
     "${MQLIB_C_API_SHARED_FLAGS[@]}" \
     -o "${MQLIB_C_API_LIBRARY}" \

--- a/src/MQLib.jl
+++ b/src/MQLib.jl
@@ -101,7 +101,7 @@ function QUBODrivers.sample(sampler::Optimizer{T}) where {T}
         ),
     )
 
-    samples, effective_time = if _mqlib_has_c_api()
+    samples, effective_time = if _mqlib_can_use_c_api(heuristic)
         _sample_with_c_api(
             T,
             n,
@@ -254,6 +254,11 @@ function _sample_with_c_api(
     return samples, t
 end
 
+function _mqlib_can_use_c_api(heuristic::Union{String,Nothing})
+    return _mqlib_has_c_api() &&
+           (!isnothing(heuristic) || _mqlib_has_hyperheuristic_data())
+end
+
 function _mqlib_has_c_api()
     return isdefined(MQLib_jll, :libmqlib_c_api)
 end
@@ -264,6 +269,11 @@ end
 
 function _mqlib_hyperheuristic_data_dir()
     return joinpath(MQLib_jll.artifact_dir, "share", "mqlib", "hhdata")
+end
+
+function _mqlib_has_hyperheuristic_data()
+    data_dir = _mqlib_hyperheuristic_data_dir()
+    return isdir(data_dir) && any(name -> endswith(name, ".rf"), readdir(data_dir))
 end
 
 function _mqlib_problem_data(n::Integer, L, Q)

--- a/src/MQLib.jl
+++ b/src/MQLib.jl
@@ -236,9 +236,9 @@ function _sample_with_c_api(
             run_time_limit,
         )
 
-        λ = T(result.objective_value)
         ψ = Int.(result.solution)
-        push!(samples, QUBODrivers.Sample{T}(ψ, α * (λ + β)))
+        λ = T(QUBOTools.value(ψ, L, Q, α, β))
+        push!(samples, QUBODrivers.Sample{T}(ψ, λ))
 
         _print_iter(
             silent,

--- a/src/MQLib.jl
+++ b/src/MQLib.jl
@@ -9,6 +9,39 @@ import MathOptInterface as MOI
 
 const __VERSION__ = v"0.1.0"
 const _HEURISTICS = Dict{String,String}()
+const _MQLIB_C_ABI_VERSION = UInt32(1)
+const _MQLIB_C_INDEX_BASE_ONE = Int32(1)
+const _MQLIB_STATUS_OK = Cint(0)
+const _MQLIB_STATUS_BUFFER_TOO_SMALL = Cint(4)
+
+struct _MQLibCQUBOInput
+    abi_version::UInt32
+    dimension::Int32
+    linear::Ptr{Cdouble}
+    quadratic_count::Int64
+    quadratic_i::Ptr{Int32}
+    quadratic_j::Ptr{Int32}
+    quadratic_value::Ptr{Cdouble}
+    index_base::Int32
+    heuristic::Cstring
+    runtime_limit_seconds::Cdouble
+    random_seed::Int32
+    hyperheuristic_data_dir::Cstring
+end
+
+struct _MQLibCQUBOResult
+    abi_version::UInt32
+    objective_value::Cdouble
+    runtime_seconds::Cdouble
+    solution::Ptr{Int32}
+    solution_length::Int32
+    selected_heuristic::Cstring
+    selected_heuristic_length::Int32
+    history_objective_values::Ptr{Cdouble}
+    history_times_seconds::Ptr{Cdouble}
+    history_capacity::Int32
+    history_length::Int32
+end
 
 function __init__()
     let exe = MQLib_jll.MQLib()
@@ -35,16 +68,6 @@ end
 function QUBODrivers.sample(sampler::Optimizer{T}) where {T}
     n, L, Q, α, β = QUBOTools.qubo(sampler, :dict; sense = :max, domain = :bool)
 
-    V = Set{Int}(1:n)
-
-    model = QUBOTools.Model{Int,T,Int}(
-        V, L, Q;
-        scale  = α,
-        offset = β,
-        sense  = :max,
-        domain = :bool,
-    )
-
     num_reads      = MOI.get(sampler, MQLib.NumberOfReads())
     silent         = MOI.get(sampler, MOI.Silent())
     heuristic      = MOI.get(sampler, MQLib.Heuristic())
@@ -69,7 +92,6 @@ function QUBODrivers.sample(sampler::Optimizer{T}) where {T}
         time_limit_sec / num_reads
     end
 
-    samples  = QUBODrivers.Sample{T,Int}[]
     metadata = Dict{String,Any}(
         "time"   => Dict{String,Any}(),
         "origin" => Dict{String,Any}(
@@ -79,7 +101,65 @@ function QUBODrivers.sample(sampler::Optimizer{T}) where {T}
         ),
     )
 
-    mktempdir() do temp_path
+    samples, effective_time = if _mqlib_has_c_api()
+        _sample_with_c_api(
+            T,
+            n,
+            L,
+            Q,
+            α,
+            β;
+            num_reads,
+            silent,
+            heuristic,
+            random_seed,
+            run_time_limit,
+        )
+    else
+        _sample_with_executable(
+            T,
+            n,
+            L,
+            Q,
+            α,
+            β;
+            num_reads,
+            silent,
+            heuristic,
+            random_seed,
+            run_time_limit,
+        )
+    end
+
+    metadata["time"]["effective"] = effective_time
+
+    return QUBOTools.SampleSet{T}(samples, metadata; sense = :max, domain = :bool)
+end
+
+function _sample_with_executable(
+    ::Type{T},
+    n::Integer,
+    L,
+    Q,
+    α,
+    β;
+    num_reads::Integer,
+    silent::Bool,
+    heuristic::Union{String,Nothing},
+    random_seed::Union{Integer,Nothing},
+    run_time_limit::Float64,
+) where {T}
+    V = Set{Int}(1:n)
+    model = QUBOTools.Model{Int,T,Int}(
+        V, L, Q;
+        scale = α,
+        offset = β,
+        sense = :max,
+        domain = :bool,
+    )
+
+    samples = QUBODrivers.Sample{T,Int}[]
+    effective_time = mktempdir() do temp_path
         file_path = joinpath(temp_path, "model.qubo")
 
         args = _mqlib_args(;
@@ -97,7 +177,7 @@ function QUBODrivers.sample(sampler::Optimizer{T}) where {T}
             _print_header(silent, heuristic)
 
             t = 0.0
-            
+
             for i = 1:num_reads
                 lines = readlines(cmd)
                 info  = split(lines[begin], ',')
@@ -118,11 +198,263 @@ function QUBODrivers.sample(sampler::Optimizer{T}) where {T}
 
             _print_footer(silent)
 
-            metadata["time"]["effective"] = t
+            t
         end
     end
 
-    return QUBOTools.SampleSet{T}(samples, metadata; sense = :max, domain = :bool)
+    return samples, effective_time
+end
+
+function _sample_with_c_api(
+    ::Type{T},
+    n::Integer,
+    L,
+    Q,
+    α,
+    β;
+    num_reads::Integer,
+    silent::Bool,
+    heuristic::Union{String,Nothing},
+    random_seed::Union{Integer,Nothing},
+    run_time_limit::Float64,
+) where {T}
+    linear, quadratic_i, quadratic_j, quadratic_value = _mqlib_problem_data(n, L, Q)
+    samples = QUBODrivers.Sample{T,Int}[]
+
+    _print_header(silent, heuristic)
+
+    t = 0.0
+    for i = 1:num_reads
+        result = _mqlib_solve_qubo(
+            n,
+            linear,
+            quadratic_i,
+            quadratic_j,
+            quadratic_value;
+            heuristic,
+            random_seed = _mqlib_run_seed(random_seed),
+            run_time_limit,
+        )
+
+        λ = T(result.objective_value)
+        ψ = Int.(result.solution)
+        push!(samples, QUBODrivers.Sample{T}(ψ, α * (λ + β)))
+
+        _print_iter(
+            silent,
+            i,
+            result.history_objective_values,
+            t .+ result.history_times_seconds,
+        )
+        t += result.runtime_seconds
+    end
+
+    _print_footer(silent)
+
+    return samples, t
+end
+
+function _mqlib_has_c_api()
+    return isdefined(MQLib_jll, :libmqlib_c_api)
+end
+
+function _mqlib_library()
+    return getproperty(MQLib_jll, :libmqlib_c_api)
+end
+
+function _mqlib_hyperheuristic_data_dir()
+    return joinpath(MQLib_jll.artifact_dir, "share", "mqlib", "hhdata")
+end
+
+function _mqlib_problem_data(n::Integer, L, Q)
+    linear = zeros(Cdouble, n)
+
+    for (i, value) in L
+        index = Int(i)
+        1 <= index <= n || error("Invalid QUBO linear index '$i'")
+        linear[index] += Cdouble(value)
+    end
+
+    quadratic_i = Int32[]
+    quadratic_j = Int32[]
+    quadratic_value = Cdouble[]
+
+    for (indices, value) in Q
+        i, j = Tuple(indices)
+        first = Int(i)
+        second = Int(j)
+        if first == second
+            1 <= first <= n || error("Invalid QUBO quadratic index '$i'")
+            linear[first] += Cdouble(value)
+        else
+            1 <= first <= n || error("Invalid QUBO quadratic index '$i'")
+            1 <= second <= n || error("Invalid QUBO quadratic index '$j'")
+            if second < first
+                first, second = second, first
+            end
+            push!(quadratic_i, Int32(first))
+            push!(quadratic_j, Int32(second))
+            push!(quadratic_value, Cdouble(value))
+        end
+    end
+
+    return linear, quadratic_i, quadratic_j, quadratic_value
+end
+
+function _mqlib_run_seed(random_seed::Union{Integer,Nothing})
+    if isnothing(random_seed)
+        return Int32(rand(0:65_535))
+    end
+
+    return Int32(mod(random_seed, 65_536))
+end
+
+function _mqlib_cstring(value::Union{AbstractString,Nothing})
+    bytes = Vector{UInt8}(codeunits(something(value, "")))
+    push!(bytes, 0x00)
+    return bytes
+end
+
+function _mqlib_status_message(status::Integer)
+    message = ccall(
+        (:mqlib_c_status_message, _mqlib_library()),
+        Cstring,
+        (Cint,),
+        Cint(status),
+    )
+
+    return unsafe_string(message)
+end
+
+function _mqlib_solve_qubo(
+    n::Integer,
+    linear::Vector{Cdouble},
+    quadratic_i::Vector{Int32},
+    quadratic_j::Vector{Int32},
+    quadratic_value::Vector{Cdouble};
+    heuristic::Union{String,Nothing},
+    random_seed::Integer,
+    run_time_limit::Float64,
+)
+    selected_capacity = Int32(64)
+    history_capacity = Int32(1024)
+
+    while true
+        call = _mqlib_call_solve_qubo(
+            n,
+            linear,
+            quadratic_i,
+            quadratic_j,
+            quadratic_value;
+            heuristic,
+            random_seed,
+            run_time_limit,
+            selected_capacity,
+            history_capacity,
+        )
+
+        status = call.status
+        result = call.result
+        if status == _MQLIB_STATUS_BUFFER_TOO_SMALL &&
+           (result.selected_heuristic_length > selected_capacity ||
+            result.history_length > history_capacity)
+            selected_capacity = max(selected_capacity, result.selected_heuristic_length)
+            history_capacity = max(history_capacity, result.history_length)
+            continue
+        elseif status != _MQLIB_STATUS_OK
+            error("MQLib C API failed: $(_mqlib_status_message(status))")
+        end
+
+        history_length = Int(result.history_length)
+        return (
+            objective_value = result.objective_value,
+            runtime_seconds = result.runtime_seconds,
+            solution = copy(call.solution[1:Int(result.solution_length)]),
+            selected_heuristic = _mqlib_selected_heuristic(
+                call.selected_heuristic,
+                result.selected_heuristic_length,
+            ),
+            history_objective_values = copy(call.history_objective_values[1:history_length]),
+            history_times_seconds = copy(call.history_times_seconds[1:history_length]),
+        )
+    end
+end
+
+function _mqlib_call_solve_qubo(
+    n::Integer,
+    linear::Vector{Cdouble},
+    quadratic_i::Vector{Int32},
+    quadratic_j::Vector{Int32},
+    quadratic_value::Vector{Cdouble};
+    heuristic::Union{String,Nothing},
+    random_seed::Integer,
+    run_time_limit::Float64,
+    selected_capacity::Integer,
+    history_capacity::Integer,
+)
+    solution = Vector{Int32}(undef, n)
+    selected_heuristic = Vector{UInt8}(undef, selected_capacity)
+    history_objective_values = Vector{Cdouble}(undef, history_capacity)
+    history_times_seconds = Vector{Cdouble}(undef, history_capacity)
+    heuristic_string = _mqlib_cstring(heuristic)
+    hhdata_dir = _mqlib_cstring(_mqlib_hyperheuristic_data_dir())
+
+    input = _MQLibCQUBOInput(
+        _MQLIB_C_ABI_VERSION,
+        Int32(n),
+        pointer(linear),
+        Int64(length(quadratic_value)),
+        pointer(quadratic_i),
+        pointer(quadratic_j),
+        pointer(quadratic_value),
+        _MQLIB_C_INDEX_BASE_ONE,
+        pointer(heuristic_string),
+        Cdouble(run_time_limit),
+        Int32(random_seed),
+        pointer(hhdata_dir),
+    )
+    result = _MQLibCQUBOResult(
+        _MQLIB_C_ABI_VERSION,
+        0.0,
+        0.0,
+        pointer(solution),
+        Int32(length(solution)),
+        pointer(selected_heuristic),
+        Int32(length(selected_heuristic)),
+        pointer(history_objective_values),
+        pointer(history_times_seconds),
+        Int32(length(history_objective_values)),
+        0,
+    )
+
+    input_ref = Ref(input)
+    result_ref = Ref(result)
+    status = GC.@preserve linear quadratic_i quadratic_j quadratic_value solution selected_heuristic history_objective_values history_times_seconds heuristic_string hhdata_dir begin
+        ccall(
+            (:mqlib_solve_qubo, _mqlib_library()),
+            Cint,
+            (Ref{_MQLibCQUBOInput}, Ref{_MQLibCQUBOResult}),
+            input_ref,
+            result_ref,
+        )
+    end
+
+    return (
+        status = status,
+        result = result_ref[],
+        solution,
+        selected_heuristic,
+        history_objective_values,
+        history_times_seconds,
+    )
+end
+
+function _mqlib_selected_heuristic(buffer::Vector{UInt8}, length::Integer)
+    if length <= 1
+        return ""
+    end
+
+    return String(buffer[1:(Int(length) - 1)])
 end
 
 function _print_header(silent::Bool, heuristic::Union{String,Nothing})

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -109,6 +109,7 @@ Test.@testset "Compatibility metadata" begin
     compat = project["compat"]
 
     Test.@test compat["julia"] == "1.10"
+    Test.@test compat["MQLib_jll"] == "0.1.2"
     Test.@test compat["QUBODrivers"] == "0.4, 0.5"
     Test.@test compat["QUBOTools"] == "0.12"
 
@@ -140,28 +141,26 @@ Test.@testset "Julia C ABI bridge" begin
         joinpath("share", "mqlib", "hhdata"),
     )
 
-    if MQLib._mqlib_has_c_api()
-        result = MQLib._mqlib_solve_qubo(
-            3,
-            linear,
-            quadratic_i,
-            quadratic_j,
-            quadratic_value;
-            heuristic = "ALKHAMIS1998",
-            random_seed = 1234,
-            run_time_limit = 0.01,
-        )
+    Test.@test MQLib._mqlib_has_c_api()
 
-        Test.@test result.objective_value == 6.0
-        Test.@test result.solution == Int32[1, 0, 1]
-        Test.@test result.selected_heuristic == "ALKHAMIS1998"
-        Test.@test result.runtime_seconds > 0.0
+    result = MQLib._mqlib_solve_qubo(
+        3,
+        linear,
+        quadratic_i,
+        quadratic_j,
+        quadratic_value;
+        heuristic = "ALKHAMIS1998",
+        random_seed = 1234,
+        run_time_limit = 0.01,
+    )
 
-        test_public_c_api_bool_max_objectives()
-        test_public_c_api_spin_max_objectives()
-    else
-        @info "Skipping direct Julia C ABI solve because MQLib_jll has no libmqlib_c_api product"
-    end
+    Test.@test result.objective_value == 6.0
+    Test.@test result.solution == Int32[1, 0, 1]
+    Test.@test result.selected_heuristic == "ALKHAMIS1998"
+    Test.@test result.runtime_seconds > 0.0
+
+    test_public_c_api_bool_max_objectives()
+    test_public_c_api_spin_max_objectives()
 end
 
 Test.@testset "C ABI contract" begin

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -24,6 +24,55 @@ function configure_public_c_api_smoke!(model)
     return model
 end
 
+function configure_public_default_hyperheuristic_smoke!(model)
+    MOI.set(model, MOI.Silent(), true)
+    MOI.set(model, MQLib.RandomSeed(), 1234)
+    MOI.set(model, MQLib.NumberOfReads(), 1)
+    MOI.set(model, MOI.TimeLimitSec(), 0.02)
+
+    return model
+end
+
+function test_public_default_hyperheuristic_succeeds()
+    T = Float64
+    n = 3
+    model = MOI.instantiate(MQLib.Optimizer; with_bridge_type = T)
+    x, _ = MOI.add_constrained_variables(model, fill(MOI.ZeroOne(), n))
+
+    MOI.set(model, MOI.ObjectiveSense(), MOI.MAX_SENSE)
+    MOI.set(
+        model,
+        MOI.ObjectiveFunction{MOI.ScalarQuadraticFunction{T}}(),
+        MOI.ScalarQuadraticFunction{T}(
+            [
+                MOI.ScalarQuadraticTerm{T}(-6, x[1], x[2]),
+                MOI.ScalarQuadraticTerm{T}(-1, x[2], x[3]),
+            ],
+            [
+                MOI.ScalarAffineTerm{T}(5, x[1]),
+                MOI.ScalarAffineTerm{T}(3, x[2]),
+                MOI.ScalarAffineTerm{T}(1, x[3]),
+            ],
+            zero(T),
+        ),
+    )
+    configure_public_default_hyperheuristic_smoke!(model)
+
+    MOI.optimize!(model)
+
+    Test.@test MOI.get(model, MOI.ResultCount()) > 0
+    Test.@test length(MOI.get.(model, MOI.VariablePrimal(), x)) == n
+
+    read_count_attr = QUBODrivers.QUBOTools_MOI.NumberOfReads
+    total_reads = sum(
+        MOI.get(model, read_count_attr(result_index))
+        for result_index = 1:MOI.get(model, MOI.ResultCount())
+    )
+    Test.@test total_reads == 1
+
+    return nothing
+end
+
 function test_public_c_api_bool_max_objectives()
     T = Float64
     n = 3
@@ -142,6 +191,10 @@ Test.@testset "Julia C ABI bridge" begin
     )
 
     Test.@test MQLib._mqlib_has_c_api()
+    Test.@test MQLib._mqlib_can_use_c_api("ALKHAMIS1998")
+    if !MQLib._mqlib_has_hyperheuristic_data()
+        Test.@test !MQLib._mqlib_can_use_c_api(nothing)
+    end
 
     result = MQLib._mqlib_solve_qubo(
         3,
@@ -161,6 +214,7 @@ Test.@testset "Julia C ABI bridge" begin
 
     test_public_c_api_bool_max_objectives()
     test_public_c_api_spin_max_objectives()
+    test_public_default_hyperheuristic_succeeds()
 end
 
 Test.@testset "C ABI contract" begin

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -35,6 +35,43 @@ Test.@testset "QUBODrivers" begin
     end
 end
 
+Test.@testset "Julia C ABI bridge" begin
+    linear_terms = Dict(1 => 5.0, 2 => 3.0, 3 => 1.0)
+    quadratic_terms = Dict((1, 2) => -6.0, (2, 3) => -1.0)
+    linear, quadratic_i, quadratic_j, quadratic_value =
+        MQLib._mqlib_problem_data(3, linear_terms, quadratic_terms)
+
+    Test.@test linear == [5.0, 3.0, 1.0]
+    Test.@test quadratic_i == Int32[1, 2]
+    Test.@test quadratic_j == Int32[2, 3]
+    Test.@test quadratic_value == [-6.0, -1.0]
+    Test.@test MQLib._mqlib_run_seed(65_536) == 0
+    Test.@test endswith(
+        MQLib._mqlib_hyperheuristic_data_dir(),
+        joinpath("share", "mqlib", "hhdata"),
+    )
+
+    if MQLib._mqlib_has_c_api()
+        result = MQLib._mqlib_solve_qubo(
+            3,
+            linear,
+            quadratic_i,
+            quadratic_j,
+            quadratic_value;
+            heuristic = "ALKHAMIS1998",
+            random_seed = 1234,
+            run_time_limit = 0.01,
+        )
+
+        Test.@test result.objective_value == 6.0
+        Test.@test result.solution == Int32[1, 0, 1]
+        Test.@test result.selected_heuristic == "ALKHAMIS1998"
+        Test.@test result.runtime_seconds > 0.0
+    else
+        @info "Skipping direct Julia C ABI solve because MQLib_jll has no libmqlib_c_api product"
+    end
+end
+
 Test.@testset "C ABI contract" begin
     root = dirname(dirname(@__FILE__))
     include_dir = joinpath(root, "c_api", "include")
@@ -85,15 +122,20 @@ Test.@testset "C ABI contract" begin
 
     recipe_text = read(recipe, String)
     for snippet in (
+        "version = v\"0.1.2\"",
         "ExecutableProduct(\"MQLib\", :MQLib)",
         "LibraryProduct(\"libmqlib_c_api\", :libmqlib_c_api)",
         "c_api/include/mqlib_c_api.h",
         "c_api/src/mqlib_c_api.cpp",
+        "mkdir -p \"\${bindir}\" \"\${libdir}\" \"\${includedir}\" \"\${datadir}/mqlib/hhdata\"",
+        "install -vm 0644 hhdata/*.rf \"\${datadir}/mqlib/hhdata/\"",
         "! -name main.cpp",
+        "MQLIB_LIBRARY_SOURCES=\"\$(find src -name '*.cpp' ! -name main.cpp | sort)\"",
         "-DMQLIB_C_BUILD_SHARED",
     )
         Test.@test occursin(snippet, recipe_text)
     end
+    Test.@test !occursin("mapfile", recipe_text)
 
     upstream_dir = get(ENV, "MQLIB_UPSTREAM_DIR", "")
     cxx = first_available_tool(["c++", "g++", "clang++"])

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -14,6 +14,95 @@ function first_available_tool(names::Vector{String})
     return nothing
 end
 
+function configure_public_c_api_smoke!(model)
+    MOI.set(model, MOI.Silent(), true)
+    MOI.set(model, MQLib.Heuristic(), "ALKHAMIS1998")
+    MOI.set(model, MQLib.RandomSeed(), 1234)
+    MOI.set(model, MQLib.NumberOfReads(), 2)
+    MOI.set(model, MOI.TimeLimitSec(), 0.02)
+
+    return model
+end
+
+function test_public_c_api_bool_max_objectives()
+    T = Float64
+    n = 3
+    Q = T[-1 2 2; 2 -1 2; 2 2 -1]
+    model = MOI.instantiate(MQLib.Optimizer; with_bridge_type = T)
+    x, _ = MOI.add_constrained_variables(model, fill(MOI.ZeroOne(), n))
+
+    MOI.set(model, MOI.ObjectiveSense(), MOI.MAX_SENSE)
+    MOI.set(
+        model,
+        MOI.ObjectiveFunction{MOI.ScalarQuadraticFunction{T}}(),
+        MOI.ScalarQuadraticFunction{T}(
+            [
+                MOI.ScalarQuadraticTerm{T}(Q[i, j], x[i], x[j])
+                for i = 1:n for j = 1:n if i != j
+            ],
+            [MOI.ScalarAffineTerm{T}(Q[i, i], x[i]) for i = 1:n],
+            T(3),
+        ),
+    )
+    configure_public_c_api_smoke!(model)
+
+    MOI.optimize!(model)
+
+    Test.@test MOI.get(model, MOI.ResultCount()) > 0
+    for result_index = 1:MOI.get(model, MOI.ResultCount())
+        xi = MOI.get.(model, MOI.VariablePrimal(result_index), x)
+        expected = sum(Q[i, j] * xi[i] * xi[j] for i = 1:n for j = 1:n) + T(3)
+        Test.@test MOI.get(model, MOI.ObjectiveValue(result_index)) ≈ expected
+    end
+
+    read_count_attr = QUBODrivers.QUBOTools_MOI.NumberOfReads
+    total_reads = sum(
+        MOI.get(model, read_count_attr(result_index))
+        for result_index = 1:MOI.get(model, MOI.ResultCount())
+    )
+    Test.@test total_reads == 2
+
+    return nothing
+end
+
+function test_public_c_api_spin_max_objectives()
+    T = Float64
+    n = 3
+    h = T[-1; -1; -1]
+    J = T[0 4 4; 0 0 4; 0 0 0]
+    model = MOI.instantiate(MQLib.Optimizer; with_bridge_type = T)
+    s, _ = MOI.add_constrained_variables(model, fill(QUBODrivers.Spin(), n))
+
+    MOI.set(model, MOI.ObjectiveSense(), MOI.MAX_SENSE)
+    MOI.set(
+        model,
+        MOI.ObjectiveFunction{MOI.ScalarQuadraticFunction{T}}(),
+        MOI.ScalarQuadraticFunction{T}(
+            [
+                MOI.ScalarQuadraticTerm{T}(J[i, j], s[i], s[j])
+                for i = 1:n for j = 1:n
+            ],
+            [MOI.ScalarAffineTerm{T}(h[i], s[i]) for i = 1:n],
+            T(5),
+        ),
+    )
+    configure_public_c_api_smoke!(model)
+
+    MOI.optimize!(model)
+
+    Test.@test MOI.get(model, MOI.ResultCount()) > 0
+    for result_index = 1:MOI.get(model, MOI.ResultCount())
+        si = MOI.get.(model, MOI.VariablePrimal(result_index), s)
+        expected =
+            sum(J[i, j] * si[i] * si[j] for i = 1:n for j = 1:n) +
+            sum(h[i] * si[i] for i = 1:n) +
+            T(5)
+        Test.@test MOI.get(model, MOI.ObjectiveValue(result_index)) ≈ expected
+    end
+
+    return nothing
+end
+
 Test.@testset "Compatibility metadata" begin
     root = dirname(dirname(@__FILE__))
     project = TOML.parsefile(joinpath(root, "Project.toml"))
@@ -67,6 +156,9 @@ Test.@testset "Julia C ABI bridge" begin
         Test.@test result.solution == Int32[1, 0, 1]
         Test.@test result.selected_heuristic == "ALKHAMIS1998"
         Test.@test result.runtime_seconds > 0.0
+
+        test_public_c_api_bool_max_objectives()
+        test_public_c_api_spin_max_objectives()
     else
         @info "Skipping direct Julia C ABI solve because MQLib_jll has no libmqlib_c_api product"
     end


### PR DESCRIPTION
## Summary

- Add a Julia `ccall` solve path that uses `MQLib_jll.libmqlib_c_api`.
- Require `MQLib_jll = "0.1.2"` now that `JuliaBinaryWrappers/MQLib_jll.jl` has published `MQLib-v0.1.2+0`.
- Keep the existing executable-backed solve path as a defensive fallback if the C ABI library product is unavailable.
- Convert QUBO dictionaries directly into C ABI buffers for linear terms, sparse quadratic terms, heuristic selection, seed, runtime limit, solution, selected heuristic, and history.
- Update the BinaryBuilder recipe sketch and docs to install/use `share/mqlib/hhdata` for hyperheuristic runs.

## Ready status

JuliaPackaging/Yggdrasil#13825 has merged, and `JuliaBinaryWrappers/MQLib_jll.jl` has published `MQLib-v0.1.2+0`. This PR now tests against the official JLL and is ready for review.

## Validation

- `/home/bernalde/.juliaup/bin/julialauncher +release --project=. -e 'using Pkg; Pkg.test()'`
  - Passed after resolving to `MQLib_jll v0.1.2+0`.
  - Direct Julia C ABI bridge test ran and passed; it no longer skips on a missing `libmqlib_c_api` product.
- `git diff --check`

Refs #8
Refs #7
Refs #3
