### PR TITLE
Clean legacy badge link and author metadata

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -1,6 +1,6 @@
 name = "MQLib"
 uuid = "16f11440-1623-44c9-850c-358a6c72f3c9"
-authors = ["pedromxavier <mail@pedro.ϵλ>", "pedroripper <pedroripper@psr-inc.com>"]
+authors = ["pedromxavier <mail@pedro.ϵλ>", "pedroripper <pedroripper@psr-inc.com>", "David E. Bernal Neira <dbernaln@purdue.edu>"]
 version = "0.5.0"
 
 [deps]

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # MQLib.jl
 [![DOI](https://zenodo.org/badge/568213607.svg)](https://zenodo.org/badge/latestdoi/568213607)
-[![QUBODRIVERS](https://img.shields.io/badge/Powered%20by-QUBODrivers.jl-%20%234063d8)](https://github.com/psrenergy/QUBODrivers.jl)
+[![QUBODRIVERS](https://img.shields.io/badge/Powered%20by-QUBODrivers.jl-%20%234063d8)](https://github.com/JuliaQUBO/QUBODrivers.jl)
 
 [MQLib](https://github.com/MQLib/MQLib) wrapper for JuMP.
 


### PR DESCRIPTION
## Summary

- Update the QUBODrivers badge link to the canonical JuliaQUBO repository.
- Add David E. Bernal Neira to `Project.toml` package authors.

Closes #16.

## Tests

- `git diff --check`
- `julia +release --project=. -e 'using Pkg; Pkg.test()'`
