### PR TITLE
Add Dependabot dependency maintenance

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,18 @@
+version: 2
+updates:
+  # Root Julia package dependencies use the public General registry. CI for
+  # Dependabot PRs only needs the default GITHUB_TOKEN, and no PAT is required
+  # because this config does not trigger cross-repository workflows.
+  - package-ecosystem: "julia"
+    directory: "/"
+    schedule:
+      interval: "weekly"
+    groups:
+      root-julia-dependencies:
+        patterns:
+          - "*"
+
+  - package-ecosystem: "github-actions"
+    directory: "/"
+    schedule:
+      interval: "monthly"


### PR DESCRIPTION
## Summary

- Add `.github/dependabot.yml` with weekly grouped Julia root dependency updates.
- Add monthly GitHub Actions dependency updates.
- Keep CompatHelper disabled, following the JuliaQUBO ecosystem policy for public packages that only use the General registry.
- Document that CI for Dependabot PRs only needs the default `GITHUB_TOKEN`; no Dependabot registries, secrets, or PAT are required because this config does not trigger cross-repository workflows.

## Checks

- `ruby -e "require 'yaml'; YAML.load_file('.github/dependabot.yml'); puts 'dependabot yaml ok'"` passed.
- `git diff --cached --check` passed before commit.

## Notes

- This repository has no `docs/` environment or documentation workflow, so the Documenter `push_preview`/Dependabot token issue described in the rollout notes does not apply here.
- `test/Project.toml` has no `[compat]` bounds, so this PR only enables the root Julia environment.
- Full Julia tests were not run because this PR only adds Dependabot configuration and does not change package code.

Closes #19
