### PR TITLE
Benchmark julia-actions/cache for CI runtime

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -28,6 +28,7 @@ jobs:
         with:
           version: ${{ matrix.version }}
           arch: ${{ matrix.arch }}
+      - uses: julia-actions/cache@v3
       - uses: julia-actions/julia-buildpkg@v1
       - name: Native C ABI smoke test
         if: runner.os == 'Linux'


### PR DESCRIPTION
Summary
- Adds `julia-actions/cache@v3` after `julia-actions/setup-julia@v3` and before `julia-actions/julia-buildpkg@v1`.
- Leaves package code and tests unchanged.
- Warm-cache benchmark meets the issue 23 material improvement threshold.

Validation
- `python -c "import pathlib, yaml; yaml.safe_load(pathlib.Path('.github/workflows/ci.yml').read_text())"`: passed
- CI run `27127936887` attempt 1: passed as the cold-cache run.
- CI run `27127936887` attempt 2: passed as the warm-cache run.

Benchmark
Baseline from issue 23: run `27072931870`.

| Job | Baseline | Cold attempt 1 | Warm attempt 2 | Warm vs baseline |
| --- | ---: | ---: | ---: | ---: |
| Julia 1.10 Ubuntu | 2m38s | 2m56s | 1m52s | -46s (-29%) |
| Julia 1 Ubuntu | 3m47s | 3m42s | 1m52s | -115s (-51%) |
| Julia 1 Windows | 4m17s | 4m36s | 2m02s | -135s (-53%) |

Critical path: `4m17s` baseline to `2m02s` warm-cache, `-135s` (`-53%`).

Step Timings

| Attempt | Job | Total | setup-julia | cache restore | julia-buildpkg | native C ABI | julia-runtest | cache save |
| --- | --- | ---: | ---: | ---: | ---: | ---: | ---: | ---: |
| Cold | Julia 1.10 Ubuntu | 2m56s | 5s | <1s | 17s | 31s | 1m48s | 10s |
| Cold | Julia 1 Ubuntu | 3m42s | 9s | <1s | 12s | 22s | 2m51s | 4s |
| Cold | Julia 1 Windows | 4m36s | 16s | 1s | 28s | skipped | 3m24s | 17s |
| Warm | Julia 1.10 Ubuntu | 1m52s | 5s | 6s | 10s | 26s | 51s | 7s |
| Warm | Julia 1 Ubuntu | 1m52s | 8s | 5s | 9s | 26s | 53s | 5s |
| Warm | Julia 1 Windows | 2m02s | 16s | 14s | 10s | skipped | 1m02s | 10s |

Cache Evidence
- Cold attempt: all three jobs logged `No cache found` and then `Cache saved successfully`.
- Warm attempt: all three jobs logged `Cache restored successfully` from attempt 1 keys, then saved attempt 2 caches.

Closes #23
