### PR TITLE
Prepare v0.7.0 release

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,8 @@
 
 ## Unreleased
 
+## v0.7.0 - 2026-06-12
+
 - Updated compatibility to QUBODrivers 0.6.1 and QUBOTools 0.13.
 - Added QUBODrivers benchmark metadata, final-read, and time-limit conformance
   declarations for the MQLib optimizer.

--- a/Project.toml
+++ b/Project.toml
@@ -1,7 +1,7 @@
 name = "MQLib"
 uuid = "16f11440-1623-44c9-850c-358a6c72f3c9"
 authors = ["pedromxavier <mail@pedro.ϵλ>", "pedroripper <pedroripper@psr-inc.com>", "David E. Bernal Neira <dbernaln@purdue.edu>"]
-version = "0.6.0"
+version = "0.7.0"
 
 [deps]
 MQLib_jll = "4dedf8fe-8d9a-5fb8-8563-19379e8d5c54"


### PR DESCRIPTION
Refs #26.

## Summary

- Bump `Project.toml` to `version = "0.7.0"`.
- Finalize the changelog section for `v0.7.0 - 2026-06-12`.

## Release rationale

This is the first driver release in the benchmark-readiness release wave and is intended to be the reference template for the remaining drivers.

The merged implementation updates MQLib to the released benchmark-conformance stack:

- `QUBODrivers = "0.6.1"`
- `QUBOTools = "0.13"`
- benchmark metadata including backend, algorithm, reads, seeds, status, and timing;
- `QUBODrivers.test(...; benchmark_conformance = true)` in CI against released dependencies.

## Validation

- `julia --project=. -e 'using TOML; project = TOML.parsefile("Project.toml"); changelog = read("CHANGELOG.md", String); @assert project["version"] == "0.7.0"; @assert occursin("## v0.7.0 - 2026-06-12", changelog); @assert project["compat"]["QUBODrivers"] == "0.6.1"; println("release metadata check passed")'`
- `git diff --check`
- `julia --project=. -e 'using Pkg; Pkg.test()'`
- `bash test/native_c_api_smoke.sh`

## After merge

- Register `v0.7.0` with JuliaRegistrator.
- Let TagBot create the tag/release after registration lands.
- Update #26 and the QUBO.jl epic once the release is registered.
