### PR TITLE
[codex] prepare v0.7.2 release

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,12 @@
 
 ## Unreleased
 
+## v0.7.2 - 2026-06-24
+
+- Allowed QUBOTools 0.15 while retaining QUBOTools 0.13 and 0.14 compatibility.
+- Made the QUBODrivers 0.6 compatibility range explicit so the package can
+  resolve with QUBODrivers 0.6.4 and the current JuliaQUBO stack.
+
 ## v0.7.1 - 2026-06-23
 
 - Allowed QUBOTools 0.14 while retaining QUBOTools 0.13 compatibility.

--- a/Project.toml
+++ b/Project.toml
@@ -1,7 +1,7 @@
 name = "MQLib"
 uuid = "16f11440-1623-44c9-850c-358a6c72f3c9"
 authors = ["pedromxavier <mail@pedro.ϵλ>", "pedroripper <pedroripper@psr-inc.com>", "David E. Bernal Neira <dbernaln@purdue.edu>"]
-version = "0.7.1"
+version = "0.7.2"
 
 [deps]
 MQLib_jll = "4dedf8fe-8d9a-5fb8-8563-19379e8d5c54"
@@ -14,6 +14,6 @@ QUBOTools = "60eb5b62-0a39-4ddc-84c5-97d2adff9319"
 MQLib_jll        = "0.1.2"
 MathOptInterface = "1"
 Printf           = "1"
-QUBOTools        = "0.13, 0.14"
-QUBODrivers      = "0.6.1"
+QUBOTools        = "0.13, 0.14, 0.15"
+QUBODrivers      = "0.6.1 - 0.6"
 julia            = "1.10"

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -179,8 +179,8 @@ Test.@testset "Compatibility metadata" begin
 
     Test.@test compat["julia"] == "1.10"
     Test.@test compat["MQLib_jll"] == "0.1.2"
-    Test.@test compat["QUBODrivers"] == "0.6.1"
-    Test.@test compat["QUBOTools"] == "0.13, 0.14"
+    Test.@test compat["QUBODrivers"] == "0.6.1 - 0.6"
+    Test.@test compat["QUBOTools"] == "0.13, 0.14, 0.15"
 
     ci = read(joinpath(root, ".github", "workflows", "ci.yml"), String)
     Test.@test occursin(r"version:\s*'1\.10'", ci)


### PR DESCRIPTION
## Summary

- Bump MQLib.jl to v0.7.2 for the current JuliaQUBO ecosystem releases.
- Allow QUBOTools 0.15 while retaining QUBOTools 0.13 and 0.14 compatibility.
- Make the QUBODrivers 0.6 compatibility range explicit so resolution can select QUBODrivers 0.6.4.
- Update compatibility metadata tests and changelog release notes.

## Registry confirmation

Confirmed in General via `gh api`:

- QUBOTools v0.15.1 is registered.
- QUBODrivers v0.6.4 is registered and its registry compat allows QUBOTools through 0.15.
- ToQUBO v0.5.1 is registered and its registry compat allows QUBOTools through 0.15 and PseudoBooleanOptimization through 0.3.
- PseudoBooleanOptimization v0.3.0 is registered.

## Validation

- `git diff --check`
- `julia --startup-file=no -e '... fresh-depot resolver with MQLib v0.7.2, QUBOTools v0.15.1, QUBODrivers v0.6.4, ToQUBO v0.5.1, PseudoBooleanOptimization v0.3.0 ...'`
- `julia --project=. -e 'using Pkg; Pkg.test(; coverage = false)'`
- `julia --startup-file=no -e '... fresh-depot Pkg.test("MQLib") with QUBOTools v0.15.1 and QUBODrivers v0.6.4 ...'`
- `MQLIB_UPSTREAM_DIR=/tmp/mqlib-upstream.cQalVl bash test/native_c_api_smoke.sh`

Docs build was not run because this repository does not have a docs project or Documenter setup.
